### PR TITLE
feat: add bounded multi-CN recovery contract

### DIFF
--- a/bounded_recovery/README.md
+++ b/bounded_recovery/README.md
@@ -1,0 +1,44 @@
+# Bounded multi-CN recovery contract
+
+This package owns the fail-closed state machine for
+`target/chaos/multi-cn-bounded-recovery-v1`.  The current CLI is deliberately
+offline-only: it can replay captured observations and verify the required
+20-attempt campaign, but it cannot inject a live fault.
+
+The state machine enforces these boundaries:
+
+- deployment image digests, cluster identity, and generation are verified
+  before any fault;
+- baseline remote execution must be verified before fault injection;
+- the first fault probe runs only in the intersection
+  `replacement Ready && old member visible`;
+- the second fault probe runs after old-member eviction;
+- readiness, membership, both probes, and cleanup share one monotonic total
+  deadline;
+- each probe has a statement-bound `remote_execution_witness/v1`;
+- raw endpoints are digested and rejected if they appear in a source artifact;
+- a missing stale window or remote scope is `not_exercised/not_evaluated`, never
+  a pass;
+- checker/observer failure is a Harness failure; cleanup failure makes the
+  attempt `infra_invalid`;
+- a campaign passes only when exactly 20 comparable, untampered attempts are
+  valid, exercised, cleanup-complete product passes.
+
+Run local tests:
+
+```bash
+python3.11 -m unittest discover -s tests -v
+```
+
+Replay one fixture without touching Kubernetes:
+
+```bash
+python3.11 -m bounded_recovery.cli replay \
+  --fixture /path/to/fixture.json \
+  --output /path/to/recovery-contract-result.json
+```
+
+The live Kubernetes/MatrixOne driver is intentionally a separate adapter.  It
+must use a fixed fault plan and typed inputs from the Nightly allowlist; this
+offline CLI will never accept a command, executable path, or arbitrary Chaos
+YAML.

--- a/bounded_recovery/__init__.py
+++ b/bounded_recovery/__init__.py
@@ -1,0 +1,13 @@
+"""Bounded multi-CN recovery contract and offline harness."""
+
+from .campaign import evaluate_campaign
+from .contract import canonical_digest, query_digest
+from .scenario import BoundedRecoveryScenario, ScenarioConfig
+
+__all__ = [
+    "BoundedRecoveryScenario",
+    "ScenarioConfig",
+    "canonical_digest",
+    "evaluate_campaign",
+    "query_digest",
+]

--- a/bounded_recovery/campaign.py
+++ b/bounded_recovery/campaign.py
@@ -1,0 +1,95 @@
+"""Offline acceptance gate for the required 20-attempt fault campaign."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+from .contract import ContractError, canonical_digest
+from .scenario import TARGET_REF, TEST_CONTRACT_ID
+
+CAMPAIGN_ATTEMPTS = 20
+
+
+def evaluate_campaign(attempts: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(attempts)
+    if len(items) != CAMPAIGN_ATTEMPTS:
+        raise ContractError(
+            f"campaign requires exactly {CAMPAIGN_ATTEMPTS} attempts, got {len(items)}"
+        )
+    attempt_ids = [item.get("attempt_id") for item in items]
+    if any(not value for value in attempt_ids) or len(set(attempt_ids)) != len(attempt_ids):
+        raise ContractError("campaign attempt IDs must be present and unique")
+    for item in items:
+        if item.get("format") != "recovery-contract-result/v1":
+            raise ContractError("campaign contains an unknown attempt format")
+        if item.get("target_ref") != TARGET_REF or item.get("test_contract_id") != TEST_CONTRACT_ID:
+            raise ContractError("campaign contains an attempt for another contract")
+        claimed_digest = item.get("content_digest")
+        rebuilt = dict(item)
+        rebuilt.pop("content_digest", None)
+        if claimed_digest != canonical_digest(rebuilt):
+            raise ContractError("campaign attempt content digest mismatch")
+
+    candidate_revisions = {item.get("candidate_revision") for item in items}
+    cluster_generations = {
+        (
+            item.get("cluster", {}).get("cluster_uid"),
+            item.get("cluster", {}).get("generation"),
+            item.get("cluster", {}).get("expected_image_digest"),
+        )
+        for item in items
+    }
+    if len(candidate_revisions) != 1 or len(cluster_generations) != 1:
+        raise ContractError("campaign attempts are not comparable")
+
+    product_counts = Counter(item.get("product_result") for item in items)
+    validity_counts = Counter(item.get("evidence_validity") for item in items)
+    stale_exercised = 0
+    all_witnesses_verified = 0
+    cleanup_ok = 0
+    for item in items:
+        probe_by_kind = {value["probe_kind"]: value for value in item.get("probes", [])}
+        stale = probe_by_kind.get("stale_window")
+        if (
+            item.get("oracle_observation", {}).get("exercise_state") == "exercised"
+            and stale is not None
+        ):
+            stale_exercised += 1
+        if set(probe_by_kind) == {"baseline", "stale_window", "post_eviction"} and all(
+            value.get("remote_execution_witness", {}).get("witness_state") == "verified"
+            for value in probe_by_kind.values()
+        ):
+            all_witnesses_verified += 1
+        if item.get("cleanup", {}).get("ok") is True:
+            cleanup_ok += 1
+
+    passed = (
+        product_counts == Counter({"passed": CAMPAIGN_ATTEMPTS})
+        and validity_counts == Counter({"valid": CAMPAIGN_ATTEMPTS})
+        and stale_exercised == CAMPAIGN_ATTEMPTS
+        and all_witnesses_verified == CAMPAIGN_ATTEMPTS
+        and cleanup_ok == CAMPAIGN_ATTEMPTS
+    )
+    result = {
+        "format": "bounded-recovery-campaign/v1",
+        "expected_attempts": CAMPAIGN_ATTEMPTS,
+        "observed_attempts": len(items),
+        "candidate_revision": next(iter(candidate_revisions)),
+        "cluster_contract": list(next(iter(cluster_generations))),
+        "product_result_counts": dict(sorted(product_counts.items())),
+        "evidence_validity_counts": dict(sorted(validity_counts.items())),
+        "stale_window_exercised": stale_exercised,
+        "all_probe_witnesses_verified": all_witnesses_verified,
+        "cleanup_ok": cleanup_ok,
+        "attempts": [
+            {
+                "attempt_id": item["attempt_id"],
+                "content_digest": item.get("content_digest", canonical_digest(item)),
+            }
+            for item in items
+        ],
+        "passed": passed,
+    }
+    result["content_digest"] = canonical_digest(result)
+    return result

--- a/bounded_recovery/campaign.py
+++ b/bounded_recovery/campaign.py
@@ -2,66 +2,498 @@
 
 from __future__ import annotations
 
+import math
+import re
 from collections import Counter
+from datetime import datetime
 from typing import Any, Iterable
 
-from .contract import ContractError, canonical_digest
-from .scenario import TARGET_REF, TEST_CONTRACT_ID
+from .contract import (
+    PROBE_KINDS,
+    SOURCE_ARTIFACT_NAMES,
+    SOURCE_KINDS,
+    SOURCE_KIND_SUFFIX,
+    ContractError,
+    canonical_digest,
+    parse_utc,
+    require_digest,
+    require_revision,
+)
+from .scenario import (
+    CONTRACT_ALLOWED_RETRIABLE_ERRORS,
+    TARGET_REF,
+    TEST_CONTRACT_ID,
+)
 
 CAMPAIGN_ATTEMPTS = 20
+ATTEMPT_FIELDS = {
+    "format",
+    "target_ref",
+    "test_contract_id",
+    "attempt_id",
+    "candidate_revision",
+    "cluster",
+    "execution_state",
+    "raw_conclusion",
+    "evidence_validity",
+    "product_result",
+    "failure_domain",
+    "failure_reason",
+    "oracle_observation",
+    "timeline",
+    "probes",
+    "cleanup",
+    "content_digest",
+}
+TIMELINE_SENTINELS = {
+    "fault_start": "not_started",
+    "replacement_ready_at": "unknown",
+    "stale_window_observed_at": "unknown",
+    "old_member_evicted_at": "unknown",
+    "stale_probe_started_at": "not_exercised",
+    "stale_probe_finished_at": "not_exercised",
+    "recovery_probe_started_at": "not_started",
+    "recovery_probe_finished_at": "not_started",
+    "recovery_frontier": "unknown",
+}
+PROBE_FIELDS = {
+    "probe_kind",
+    "statement_id",
+    "query_digest",
+    "started_at_utc",
+    "finished_at_utc",
+    "duration_seconds",
+    "outcome",
+    "consistency_ok",
+    "error_class",
+    "remote_execution_witness",
+    "remote_execution_witness_digest",
+}
+WITNESS_FIELDS = {
+    "format",
+    "probe_kind",
+    "candidate_revision",
+    "cluster",
+    "query",
+    "fault_target",
+    "remote_scopes",
+    "witness_state",
+    "source_artifacts",
+}
+ALLOWED_PROBE_SEQUENCES = {
+    (),
+    ("baseline",),
+    ("baseline", "stale_window"),
+    ("baseline", "post_eviction"),
+    tuple(PROBE_KINDS),
+}
+CLEANUP_DETAIL_RE = re.compile(
+    r"^cleanup_detail; diagnostic_digest=sha256:[0-9a-f]{64}; "
+    r"source_truncated=(?:true|false)$"
+)
+
+
+def _record(value: Any, fields: set[str], path: str) -> dict[str, Any]:
+    if type(value) is not dict or value.keys() != fields:
+        raise ContractError(f"{path} schema mismatch")
+    return value
+
+
+def _array(value: Any, limit: int, path: str) -> list[Any]:
+    if type(value) is not list or len(value) > limit:
+        raise ContractError(f"{path} must be a bounded array")
+    return value
+
+
+def _text(value: Any, path: str, limit: int = 4096) -> str:
+    if type(value) is not str or not value or len(value) > limit:
+        raise ContractError(f"{path} must be a non-empty bounded string")
+    return value
+
+
+def _sha(value: Any, path: str) -> str:
+    return require_digest(_text(value, path, 71), path)
+
+
+def _utc(value: Any, path: str) -> datetime:
+    return parse_utc(_text(value, path, 40))
+
+
+def _choice(value: Any, allowed: set[str], path: str) -> str:
+    if type(value) is not str or value not in allowed:
+        raise ContractError(f"{path} is outside the contract")
+    return value
+
+
+def _validate_timeline(value: Any) -> tuple[dict[str, Any], dict[str, datetime]]:
+    timeline = _record(
+        value, set(TIMELINE_SENTINELS) | {"scenario_deadline"}, "attempt.timeline"
+    )
+    deadline = _utc(timeline["scenario_deadline"], "attempt.timeline.scenario_deadline")
+    concrete = {"scenario_deadline": deadline}
+    for field, sentinel in TIMELINE_SENTINELS.items():
+        raw = _text(timeline[field], f"attempt.timeline.{field}", 40)
+        if raw == sentinel:
+            continue
+        observed = _utc(raw, f"attempt.timeline.{field}")
+        if observed > deadline:
+            raise ContractError(f"attempt.timeline.{field} exceeds the deadline")
+        concrete[field] = observed
+    for started, finished in (
+        ("stale_probe_started_at", "stale_probe_finished_at"),
+        ("recovery_probe_started_at", "recovery_probe_finished_at"),
+    ):
+        if (started in concrete) != (finished in concrete):
+            raise ContractError("attempt timeline probe bounds are incomplete")
+        if started in concrete and concrete[finished] < concrete[started]:
+            raise ContractError("attempt timeline probe finished before it started")
+    if ("recovery_frontier" in concrete) != (
+        "recovery_probe_finished_at" in concrete
+    ):
+        raise ContractError("attempt recovery frontier is incomplete")
+    if (
+        "recovery_frontier" in concrete
+        and concrete["recovery_frontier"] != concrete["recovery_probe_finished_at"]
+    ):
+        raise ContractError("attempt recovery frontier does not match the probe")
+    return timeline, concrete
+
+
+def _validate_witness(
+    witness_value: Any,
+    *,
+    revision: str,
+    attempt_cluster: dict[str, Any],
+    probe: dict[str, Any],
+) -> None:
+    witness = _record(witness_value, WITNESS_FIELDS, "attempt.probe.witness")
+    if (
+        witness["format"] != "remote_execution_witness/v1"
+        or witness["probe_kind"] != probe["probe_kind"]
+        or witness["candidate_revision"] != revision
+    ):
+        raise ContractError("attempt probe witness identity mismatch")
+
+    cluster = _record(
+        witness["cluster"],
+        {"cluster_uid", "generation", "coordinator_cn"},
+        "attempt.probe.witness.cluster",
+    )
+    if (
+        cluster["cluster_uid"] != attempt_cluster["cluster_uid"]
+        or cluster["generation"] != attempt_cluster["generation"]
+    ):
+        raise ContractError("attempt probe witness cluster mismatch")
+    coordinator = _sha(cluster["coordinator_cn"], "attempt.probe.witness.coordinator")
+
+    query = _record(
+        witness["query"],
+        {"statement_id", "query_digest", "started_at_utc", "finished_at_utc"},
+        "attempt.probe.witness.query",
+    )
+    linked_fields = ("statement_id", "query_digest", "started_at_utc", "finished_at_utc")
+    if any(query[field] != probe[field] for field in linked_fields):
+        raise ContractError("attempt probe witness query mismatch")
+    query_started = _utc(query["started_at_utc"], "attempt.probe.witness.query.start")
+    query_finished = _utc(query["finished_at_utc"], "attempt.probe.witness.query.finish")
+
+    fault_target = _record(
+        witness["fault_target"],
+        {"cn", "endpoint_digest"},
+        "attempt.probe.witness.fault_target",
+    )
+    _sha(fault_target["cn"], "attempt.probe.witness.fault_target.cn")
+    _sha(
+        fault_target["endpoint_digest"],
+        "attempt.probe.witness.fault_target.endpoint_digest",
+    )
+
+    source_kinds: set[str] = set()
+    scopes = _array(witness["remote_scopes"], 16, "attempt.probe.witness.scopes")
+    for scope_value in scopes:
+        scope = _record(
+            scope_value,
+            {
+                "remote_cn",
+                "endpoint_digest",
+                "first_observed_at_utc",
+                "last_observed_at_utc",
+                "source_kind",
+            },
+            "attempt.probe.witness.scope",
+        )
+        if _sha(scope["remote_cn"], "attempt.probe.witness.scope.remote_cn") == coordinator:
+            raise ContractError("attempt probe witness scope is not remote")
+        _sha(scope["endpoint_digest"], "attempt.probe.witness.scope.endpoint")
+        first = _utc(scope["first_observed_at_utc"], "attempt.probe.witness.scope.first")
+        last = _utc(scope["last_observed_at_utc"], "attempt.probe.witness.scope.last")
+        if not query_started <= first <= last <= query_finished:
+            raise ContractError("attempt probe witness scope is outside its query")
+        source_kinds.add(
+            _choice(scope["source_kind"], set(SOURCE_KINDS), "attempt.probe.witness.source")
+        )
+
+    artifact_names: set[str] = set()
+    artifacts = _array(
+        witness["source_artifacts"], 8, "attempt.probe.witness.source_artifacts"
+    )
+    for artifact_value in artifacts:
+        artifact = _record(
+            artifact_value,
+            {"logical_name", "digest"},
+            "attempt.probe.witness.source_artifact",
+        )
+        name = _text(artifact["logical_name"], "attempt.probe.witness.artifact", 128)
+        if name in artifact_names or name not in SOURCE_ARTIFACT_NAMES[probe["probe_kind"]]:
+            raise ContractError("attempt probe witness artifact is not allowlisted and unique")
+        artifact_names.add(name)
+        _sha(artifact["digest"], "attempt.probe.witness.artifact.digest")
+
+    state = _choice(
+        witness["witness_state"],
+        {"verified", "mismatch", "not_observed"},
+        "attempt.probe.witness.state",
+    )
+    linked_source = any(
+        f"{probe['probe_kind']}-{SOURCE_KIND_SUFFIX[source_kind]}" in artifact_names
+        for source_kind in source_kinds
+    )
+    if state == "verified" and (not scopes or not linked_source):
+        raise ContractError("verified attempt probe witness is incomplete")
+
+
+def _validate_probe(
+    value: Any, revision: str, cluster: dict[str, Any], deadline: datetime
+) -> dict[str, Any]:
+    probe = _record(value, PROBE_FIELDS, "attempt.probe")
+    _choice(probe["probe_kind"], set(PROBE_KINDS), "attempt.probe.kind")
+    _text(probe["statement_id"], "attempt.probe.statement_id", 256)
+    _sha(probe["query_digest"], "attempt.probe.query_digest")
+    started = _utc(probe["started_at_utc"], "attempt.probe.start")
+    finished = _utc(probe["finished_at_utc"], "attempt.probe.finish")
+    if not started <= finished <= deadline:
+        raise ContractError("attempt probe is outside the scenario deadline")
+    duration = probe["duration_seconds"]
+    if type(duration) not in (int, float) or not math.isfinite(duration) or duration < 0:
+        raise ContractError("attempt probe duration must be finite and non-negative")
+    _text(probe["outcome"], "attempt.probe.outcome", 64)
+    if type(probe["consistency_ok"]) is not bool and probe["consistency_ok"] is not None:
+        raise ContractError("attempt probe consistency must be boolean or null")
+    if probe["error_class"] is not None:
+        _text(probe["error_class"], "attempt.probe.error_class", 256)
+    _validate_witness(
+        probe["remote_execution_witness"],
+        revision=revision,
+        attempt_cluster=cluster,
+        probe=probe,
+    )
+    witness_digest = _sha(
+        probe["remote_execution_witness_digest"], "attempt.probe.witness_digest"
+    )
+    if witness_digest != canonical_digest(probe["remote_execution_witness"]):
+        raise ContractError("attempt probe witness digest mismatch")
+    return probe
+
+
+def validate_attempt_result(value: Any) -> None:
+    """Fail closed unless value is one exact final state-machine result."""
+
+    attempt = _record(value, ATTEMPT_FIELDS, "attempt")
+    claimed_digest = _sha(attempt["content_digest"], "attempt.content_digest")
+    unsigned = dict(attempt)
+    unsigned.pop("content_digest")
+    if (
+        attempt["format"] != "recovery-contract-result/v1"
+        or attempt["target_ref"] != TARGET_REF
+        or attempt["test_contract_id"] != TEST_CONTRACT_ID
+    ):
+        raise ContractError("campaign contains an attempt for another contract")
+
+    _text(attempt["attempt_id"], "attempt.attempt_id", 256)
+    revision = require_revision(_text(attempt["candidate_revision"], "attempt.revision", 40))
+    cluster = _record(
+        attempt["cluster"],
+        {"cluster_uid", "generation", "expected_image_digest"},
+        "attempt.cluster",
+    )
+    _sha(cluster["cluster_uid"], "attempt.cluster.cluster_uid")
+    _text(cluster["generation"], "attempt.cluster.generation", 256)
+    _sha(cluster["expected_image_digest"], "attempt.cluster.image")
+
+    execution = _choice(attempt["execution_state"], {"blocked", "completed"}, "attempt.execution")
+    conclusion = _choice(
+        attempt["raw_conclusion"], {"success", "failure", "timed_out"}, "attempt.conclusion"
+    )
+    validity = _choice(
+        attempt["evidence_validity"],
+        {"valid", "partial", "mismatch", "infra_invalid"},
+        "attempt.validity",
+    )
+    product = _choice(
+        attempt["product_result"],
+        {"passed", "failed", "not_evaluated"},
+        "attempt.product_result",
+    )
+    domain = attempt["failure_domain"]
+    if domain is not None:
+        domain = _choice(domain, {"product", "harness", "infra"}, "attempt.failure_domain")
+    reason = attempt["failure_reason"]
+    if reason is not None:
+        _text(reason, "attempt.failure_reason", 512)
+    oracle = _record(
+        attempt["oracle_observation"], {"exercise_state"}, "attempt.oracle"
+    )
+    exercise = _choice(
+        oracle["exercise_state"], {"exercised", "not_exercised"}, "attempt.exercise"
+    )
+
+    timeline, concrete = _validate_timeline(attempt["timeline"])
+    deadline = concrete["scenario_deadline"]
+    probes = [
+        _validate_probe(probe, revision, cluster, deadline)
+        for probe in _array(attempt["probes"], len(PROBE_KINDS), "attempt.probes")
+    ]
+    probe_kinds = tuple(probe["probe_kind"] for probe in probes)
+    if probe_kinds not in ALLOWED_PROBE_SEQUENCES:
+        raise ContractError("attempt probe sequence is outside the state machine")
+
+    cleanup = attempt["cleanup"]
+    cleanup_finished = None
+    if cleanup is not None:
+        cleanup = _record(
+            cleanup, {"ok", "finished_at_utc", "detail"}, "attempt.cleanup"
+        )
+        if type(cleanup["ok"]) is not bool:
+            raise ContractError("attempt.cleanup.ok must be a boolean")
+        cleanup_finished = _utc(cleanup["finished_at_utc"], "attempt.cleanup.finish")
+        if type(cleanup["detail"]) is not str or len(cleanup["detail"]) > 160:
+            raise ContractError("attempt.cleanup.detail must be bounded")
+        if cleanup["detail"] and not CLEANUP_DETAIL_RE.fullmatch(cleanup["detail"]):
+            raise ContractError("attempt.cleanup.detail is not redacted")
+
+    if product == "passed":
+        if (
+            (execution, conclusion, validity, domain, reason, exercise)
+            != ("completed", "success", "valid", None, None, "exercised")
+            or cleanup is None
+            or cleanup["ok"] is not True
+            or cleanup_finished is None
+            or cleanup_finished > deadline
+            or probe_kinds != tuple(PROBE_KINDS)
+        ):
+            raise ContractError("passed attempt result axes are inconsistent")
+        by_kind = {probe["probe_kind"]: probe for probe in probes}
+        baseline, stale, recovery = (by_kind[kind] for kind in PROBE_KINDS)
+        if any(
+            probe["remote_execution_witness"]["witness_state"] != "verified"
+            for probe in probes
+        ):
+            raise ContractError("passed attempt has an unverified witness")
+        boundary_probes_pass = all(
+            probe["outcome"] == "success"
+            and probe["consistency_ok"] is True
+            and probe["error_class"] is None
+            for probe in (baseline, recovery)
+        )
+        stale_passes = (
+            stale["outcome"] == "success"
+            and stale["consistency_ok"] is True
+            and stale["error_class"] is None
+        ) or (
+            stale["outcome"] == "retriable_error"
+            and stale["consistency_ok"] is None
+            and stale["error_class"] in CONTRACT_ALLOWED_RETRIABLE_ERRORS
+        )
+        if not boundary_probes_pass or not stale_passes:
+            raise ContractError("passed attempt probe outcomes are inconsistent")
+        if not set(TIMELINE_SENTINELS).issubset(concrete):
+            raise ContractError("passed attempt timeline is incomplete")
+        if not (
+            _utc(baseline["finished_at_utc"], "baseline.finish")
+            <= concrete["fault_start"]
+            <= concrete["replacement_ready_at"]
+            <= concrete["stale_window_observed_at"]
+            <= concrete["stale_probe_started_at"]
+            <= concrete["stale_probe_finished_at"]
+            <= concrete["old_member_evicted_at"]
+            <= concrete["recovery_probe_started_at"]
+            <= concrete["recovery_probe_finished_at"]
+            <= cleanup_finished
+            <= deadline
+        ):
+            raise ContractError("passed attempt timeline is not monotonic")
+        if (
+            timeline["stale_probe_started_at"] != stale["started_at_utc"]
+            or timeline["stale_probe_finished_at"] != stale["finished_at_utc"]
+            or timeline["recovery_probe_started_at"] != recovery["started_at_utc"]
+            or timeline["recovery_probe_finished_at"] != recovery["finished_at_utc"]
+            or timeline["recovery_frontier"] != recovery["finished_at_utc"]
+        ):
+            raise ContractError("passed attempt timeline does not match its probes")
+    elif product == "failed":
+        if (
+            validity != "valid"
+            or domain != "product"
+            or conclusion not in {"failure", "timed_out"}
+            or reason is None
+        ):
+            raise ContractError("failed attempt result axes are inconsistent")
+    else:
+        if validity == "valid" or reason is None:
+            raise ContractError("not-evaluated attempt result axes are inconsistent")
+        if validity == "infra_invalid" and domain != "infra":
+            raise ContractError("infra-invalid attempt must have an infra failure")
+
+    if claimed_digest != canonical_digest(unsigned):
+        raise ContractError("campaign attempt content digest mismatch")
 
 
 def evaluate_campaign(attempts: Iterable[dict[str, Any]]) -> dict[str, Any]:
-    items = list(attempts)
+    items = []
+    for item in attempts:
+        items.append(item)
+        if len(items) > CAMPAIGN_ATTEMPTS:
+            break
     if len(items) != CAMPAIGN_ATTEMPTS:
         raise ContractError(
             f"campaign requires exactly {CAMPAIGN_ATTEMPTS} attempts, got {len(items)}"
         )
-    attempt_ids = [item.get("attempt_id") for item in items]
-    if any(not value for value in attempt_ids) or len(set(attempt_ids)) != len(attempt_ids):
-        raise ContractError("campaign attempt IDs must be present and unique")
     for item in items:
-        if item.get("format") != "recovery-contract-result/v1":
-            raise ContractError("campaign contains an unknown attempt format")
-        if item.get("target_ref") != TARGET_REF or item.get("test_contract_id") != TEST_CONTRACT_ID:
-            raise ContractError("campaign contains an attempt for another contract")
-        claimed_digest = item.get("content_digest")
-        rebuilt = dict(item)
-        rebuilt.pop("content_digest", None)
-        if claimed_digest != canonical_digest(rebuilt):
-            raise ContractError("campaign attempt content digest mismatch")
+        validate_attempt_result(item)
+    attempt_ids = [item["attempt_id"] for item in items]
+    if len(set(attempt_ids)) != len(attempt_ids):
+        raise ContractError("campaign attempt IDs must be unique")
 
-    candidate_revisions = {item.get("candidate_revision") for item in items}
+    candidate_revisions = {item["candidate_revision"] for item in items}
     cluster_generations = {
         (
-            item.get("cluster", {}).get("cluster_uid"),
-            item.get("cluster", {}).get("generation"),
-            item.get("cluster", {}).get("expected_image_digest"),
+            item["cluster"]["cluster_uid"],
+            item["cluster"]["generation"],
+            item["cluster"]["expected_image_digest"],
         )
         for item in items
     }
     if len(candidate_revisions) != 1 or len(cluster_generations) != 1:
         raise ContractError("campaign attempts are not comparable")
 
-    product_counts = Counter(item.get("product_result") for item in items)
-    validity_counts = Counter(item.get("evidence_validity") for item in items)
+    product_counts = Counter(item["product_result"] for item in items)
+    validity_counts = Counter(item["evidence_validity"] for item in items)
     stale_exercised = 0
     all_witnesses_verified = 0
     cleanup_ok = 0
     for item in items:
-        probe_by_kind = {value["probe_kind"]: value for value in item.get("probes", [])}
-        stale = probe_by_kind.get("stale_window")
+        probe_by_kind = {value["probe_kind"]: value for value in item["probes"]}
         if (
-            item.get("oracle_observation", {}).get("exercise_state") == "exercised"
-            and stale is not None
+            item["oracle_observation"]["exercise_state"] == "exercised"
+            and "stale_window" in probe_by_kind
         ):
             stale_exercised += 1
-        if set(probe_by_kind) == {"baseline", "stale_window", "post_eviction"} and all(
-            value.get("remote_execution_witness", {}).get("witness_state") == "verified"
+        if set(probe_by_kind) == set(PROBE_KINDS) and all(
+            value["remote_execution_witness"]["witness_state"] == "verified"
             for value in probe_by_kind.values()
         ):
             all_witnesses_verified += 1
-        if item.get("cleanup", {}).get("ok") is True:
+        if item["cleanup"] is not None and item["cleanup"]["ok"] is True:
             cleanup_ok += 1
 
     passed = (
@@ -85,7 +517,7 @@ def evaluate_campaign(attempts: Iterable[dict[str, Any]]) -> dict[str, Any]:
         "attempts": [
             {
                 "attempt_id": item["attempt_id"],
-                "content_digest": item.get("content_digest", canonical_digest(item)),
+                "content_digest": item["content_digest"],
             }
             for item in items
         ],

--- a/bounded_recovery/cli.py
+++ b/bounded_recovery/cli.py
@@ -1,0 +1,92 @@
+"""Offline replay CLI.  It never performs a live fault injection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from .campaign import evaluate_campaign
+from .contract import canonical_json
+from .replay import ReplayDriver
+from .scenario import BoundedRecoveryScenario, ScenarioConfig
+
+
+def _load(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def _write_atomic(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    with temporary.open("wb") as stream:
+        stream.write(canonical_json(value))
+        stream.flush()
+        os.fsync(stream.fileno())
+    temporary.replace(path)
+
+
+def _config(value: dict[str, Any]) -> ScenarioConfig:
+    return ScenarioConfig(
+        candidate_revision=value["candidate_revision"],
+        cluster_uid=value["cluster_uid"],
+        generation=value["generation"],
+        expected_image_digest=value["expected_image_digest"],
+        scenario_budget_seconds=float(value.get("scenario_budget_seconds", 1800)),
+        probe_budget_seconds=float(value.get("probe_budget_seconds", 30)),
+        poll_interval_seconds=float(value.get("poll_interval_seconds", 1)),
+    )
+
+
+def replay(args: argparse.Namespace) -> int:
+    fixture = _load(args.fixture)
+    partial_path = args.output.with_name("partial-recovery-contract-result.json")
+    scenario = BoundedRecoveryScenario(
+        _config(fixture["config"]),
+        ReplayDriver(fixture),
+        attempt_id=fixture["attempt_id"],
+        on_partial=lambda value: _write_atomic(partial_path, value),
+    )
+    result = scenario.run()
+    _write_atomic(args.output, result)
+    return 0 if result["product_result"] == "passed" and result["evidence_validity"] == "valid" else 1
+
+
+def campaign(args: argparse.Namespace) -> int:
+    attempts = [_load(path) for path in args.attempt]
+    result = evaluate_campaign(attempts)
+    _write_atomic(args.output, result)
+    return 0 if result["passed"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    replay_parser = subparsers.add_parser("replay", help="replay one offline fixture")
+    replay_parser.add_argument("--fixture", type=Path, required=True)
+    replay_parser.add_argument("--output", type=Path, required=True)
+    replay_parser.set_defaults(handler=replay)
+
+    campaign_parser = subparsers.add_parser("campaign", help="verify a fixed offline campaign")
+    campaign_parser.add_argument("--attempt", type=Path, action="append", required=True)
+    campaign_parser.add_argument("--output", type=Path, required=True)
+    campaign_parser.set_defaults(handler=campaign)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (KeyError, TypeError, ValueError) as exc:
+        print(f"bounded recovery contract error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bounded_recovery/contract.py
+++ b/bounded_recovery/contract.py
@@ -1,0 +1,258 @@
+"""Canonical evidence helpers for the bounded multi-CN recovery scenario.
+
+Raw endpoints and Kubernetes identities are deliberately accepted only at the
+scenario boundary.  Evidence produced by this module contains stable digests,
+never those raw values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+PROBE_KINDS = ("baseline", "stale_window", "post_eviction")
+SOURCE_KINDS = ("query_trace", "runtime_trace", "bounded_cn_log")
+SOURCE_KIND_SUFFIX = {
+    "query_trace": "query-trace.json",
+    "runtime_trace": "runtime-trace.json",
+    "bounded_cn_log": "cn-log.json",
+}
+SOURCE_ARTIFACT_NAMES = {
+    kind: {
+        f"{kind}-query-trace.json",
+        f"{kind}-runtime-trace.json",
+        f"{kind}-cn-log.json",
+    }
+    for kind in PROBE_KINDS
+}
+
+
+class ContractError(ValueError):
+    """Raised when evidence cannot satisfy the versioned contract."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def canonical_digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def content_digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def query_digest(sql: str) -> str:
+    # The scenario owns the exact query text.  Do not normalize it with the
+    # product parser or the independent oracle could drift with the product.
+    return content_digest(sql.encode("utf-8"))
+
+
+def stable_identity(value: str) -> str:
+    if not value:
+        raise ContractError("stable identity source is empty")
+    return content_digest(value.encode("utf-8"))
+
+
+def require_revision(value: str) -> str:
+    if not REVISION_RE.fullmatch(value):
+        raise ContractError("candidate_revision must be a lowercase 40-character SHA")
+    return value
+
+
+def require_digest(value: str, field: str) -> str:
+    if not SHA256_RE.fullmatch(value):
+        raise ContractError(f"{field} must be a sha256 digest")
+    return value
+
+
+def parse_utc(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise ContractError("timestamps must use RFC3339 UTC with a Z suffix")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ContractError(f"invalid UTC timestamp: {value}") from exc
+    if parsed.tzinfo != timezone.utc:
+        raise ContractError("timestamp is not UTC")
+    return parsed
+
+
+@dataclass(frozen=True)
+class SourceArtifact:
+    logical_name: str
+    content: bytes
+
+
+@dataclass(frozen=True)
+class RemoteScopeObservation:
+    probe_kind: str
+    statement_id: str
+    query_digest: str
+    coordinator_cn: str
+    remote_cn: str
+    endpoint: str
+    first_observed_at_utc: str
+    last_observed_at_utc: str
+    source_kind: str
+
+
+def build_remote_execution_witness(
+    *,
+    probe_kind: str,
+    candidate_revision: str,
+    cluster_uid: str,
+    generation: str,
+    coordinator_cn: str,
+    statement_id: str,
+    probe_query_digest: str,
+    started_at_utc: str,
+    finished_at_utc: str,
+    fault_target_cn: str,
+    fault_endpoint: str,
+    observations: Iterable[RemoteScopeObservation],
+    source_artifacts: Iterable[SourceArtifact],
+    max_remote_scopes: int = 16,
+    max_source_artifacts: int = 8,
+    max_source_artifact_bytes: int = 1 << 20,
+) -> dict[str, Any]:
+    if probe_kind not in PROBE_KINDS:
+        raise ContractError(f"unsupported probe_kind: {probe_kind}")
+    require_revision(candidate_revision)
+    require_digest(probe_query_digest, "query_digest")
+    if not statement_id:
+        raise ContractError("statement_id is empty")
+    started = parse_utc(started_at_utc)
+    finished = parse_utc(finished_at_utc)
+    if finished < started:
+        raise ContractError("probe finished before it started")
+
+    observed = list(observations)
+    artifacts = list(source_artifacts)
+    if len(observed) > max_remote_scopes:
+        raise ContractError("remote scope count exceeds the contract limit")
+    if len(artifacts) > max_source_artifacts:
+        raise ContractError("source artifact count exceeds the contract limit")
+    if sum(len(item.content) for item in artifacts) > max_source_artifact_bytes:
+        raise ContractError("source artifact bytes exceed the contract limit")
+    artifact_names = [item.logical_name for item in artifacts]
+    if len(set(artifact_names)) != len(artifact_names):
+        raise ContractError("source artifact logical names must be unique")
+    if any(name not in SOURCE_ARTIFACT_NAMES[probe_kind] for name in artifact_names):
+        raise ContractError("source artifact logical name is not allowlisted")
+    raw_endpoint_bytes = [
+        value.encode("utf-8")
+        for value in (fault_endpoint, *(item.endpoint for item in observed))
+        if value
+    ]
+    if any(raw in artifact.content for raw in raw_endpoint_bytes for artifact in artifacts):
+        raise ContractError("source artifact contains a raw endpoint")
+    statement_bytes = statement_id.encode("utf-8")
+    query_digest_bytes = probe_query_digest.encode("utf-8")
+    linked_source_kinds = {
+        source_kind
+        for source_kind, suffix in SOURCE_KIND_SUFFIX.items()
+        if any(
+            artifact.logical_name == f"{probe_kind}-{suffix}"
+            and statement_bytes in artifact.content
+            and query_digest_bytes in artifact.content
+            for artifact in artifacts
+        )
+    }
+
+    mismatch = False
+    remote_scopes: list[dict[str, str]] = []
+    for item in observed:
+        first = parse_utc(item.first_observed_at_utc)
+        last = parse_utc(item.last_observed_at_utc)
+        identity_matches = (
+            item.probe_kind == probe_kind
+            and item.statement_id == statement_id
+            and item.query_digest == probe_query_digest
+            and item.coordinator_cn == coordinator_cn
+        )
+        window_matches = started <= first <= last <= finished
+        remote_matches = bool(item.remote_cn) and item.remote_cn != coordinator_cn
+        source_matches = item.source_kind in SOURCE_KINDS
+        if not (identity_matches and window_matches and remote_matches and source_matches):
+            mismatch = True
+            continue
+        remote_scopes.append(
+            {
+                "remote_cn": stable_identity(item.remote_cn),
+                "endpoint_digest": stable_identity(item.endpoint),
+                "first_observed_at_utc": item.first_observed_at_utc,
+                "last_observed_at_utc": item.last_observed_at_utc,
+                "source_kind": item.source_kind,
+            }
+        )
+
+    if mismatch:
+        witness_state = "mismatch"
+    elif remote_scopes and any(
+        item["source_kind"] in linked_source_kinds for item in remote_scopes
+    ):
+        witness_state = "verified"
+    elif remote_scopes and artifacts:
+        witness_state = "mismatch"
+    else:
+        witness_state = "not_observed"
+
+    remote_scopes.sort(
+        key=lambda item: (
+            item["remote_cn"],
+            item["endpoint_digest"],
+            item["first_observed_at_utc"],
+            item["last_observed_at_utc"],
+            item["source_kind"],
+        )
+    )
+    artifacts.sort(key=lambda item: item.logical_name)
+
+    result = {
+        "format": "remote_execution_witness/v1",
+        "probe_kind": probe_kind,
+        "candidate_revision": candidate_revision,
+        "cluster": {
+            "cluster_uid": stable_identity(cluster_uid),
+            "generation": generation,
+            "coordinator_cn": stable_identity(coordinator_cn),
+        },
+        "query": {
+            "statement_id": statement_id,
+            "query_digest": probe_query_digest,
+            "started_at_utc": started_at_utc,
+            "finished_at_utc": finished_at_utc,
+        },
+        "fault_target": {
+            "cn": stable_identity(fault_target_cn),
+            "endpoint_digest": stable_identity(fault_endpoint),
+        },
+        "remote_scopes": remote_scopes,
+        "witness_state": witness_state,
+        "source_artifacts": [
+            {
+                "logical_name": artifact.logical_name,
+                "digest": content_digest(artifact.content),
+            }
+            for artifact in artifacts
+        ],
+    }
+    # This assertion also protects future edits from accidentally serializing
+    # a raw endpoint through a newly added field.
+    encoded = canonical_json(result).decode("utf-8")
+    for raw in (fault_endpoint, *(item.endpoint for item in observed)):
+        if raw and raw in encoded:
+            raise ContractError("remote witness leaked a raw endpoint")
+    return result

--- a/bounded_recovery/replay.py
+++ b/bounded_recovery/replay.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from .contract import RemoteScopeObservation, SourceArtifact
+from .contract import ContractError, RemoteScopeObservation, SourceArtifact
 from .scenario import (
     CleanupReceipt,
     DeploymentObservation,
@@ -19,6 +19,12 @@ from .scenario import (
 
 def _utc(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _require_json_bool(value: Any, field: str) -> bool:
+    if type(value) is not bool:
+        raise ContractError(f"{field} must be a JSON boolean")
+    return value
 
 
 @dataclass
@@ -118,8 +124,12 @@ class ReplayDriver:
         self._time = max(self._time, float(item["at_seconds"]))
         return TopologyObservation(
             observed_at_utc=self.utc_now(),
-            replacement_ready=bool(item["replacement_ready"]),
-            old_member_visible=bool(item["old_member_visible"]),
+            replacement_ready=_require_json_bool(
+                item["replacement_ready"], "topology.replacement_ready"
+            ),
+            old_member_visible=_require_json_bool(
+                item["old_member_visible"], "topology.old_member_visible"
+            ),
         )
 
     def wait(self, seconds: float, deadline: float) -> None:
@@ -134,7 +144,7 @@ class ReplayDriver:
         item = self.fixture.get("cleanup", {"ok": True})
         self._time += float(item.get("duration_seconds", 0))
         return CleanupReceipt(
-            ok=bool(item["ok"]),
+            ok=_require_json_bool(item["ok"], "cleanup.ok"),
             finished_at_utc=self.utc_now(),
             detail=item.get("detail", ""),
         )

--- a/bounded_recovery/replay.py
+++ b/bounded_recovery/replay.py
@@ -1,0 +1,140 @@
+"""Deterministic driver for offline scenario and campaign verification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .contract import RemoteScopeObservation, SourceArtifact
+from .scenario import (
+    CleanupReceipt,
+    DeploymentObservation,
+    FaultReceipt,
+    HarnessFailure,
+    ProbeResult,
+    TopologyObservation,
+)
+
+
+def _utc(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+@dataclass
+class ReplayDriver:
+    fixture: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        self._time = 0.0
+        self._start = _utc(self.fixture["started_at_utc"])
+        self._topology_index = 0
+        self.cleanup_calls = 0
+
+    def monotonic(self) -> float:
+        return self._time
+
+    def utc_now(self) -> str:
+        value = self._start + timedelta(seconds=self._time)
+        return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace(
+            "+00:00", "Z"
+        )
+
+    def preflight(self, deadline: float) -> DeploymentObservation:
+        del deadline
+        item = self.fixture["deployment"]
+        self._time += float(item.get("duration_seconds", 0))
+        return DeploymentObservation(
+            cluster_uid=item["cluster_uid"],
+            generation=item["generation"],
+            image_digests=tuple(item["image_digests"]),
+            fault_target_cn=item["fault_target_cn"],
+            fault_endpoint=item["fault_endpoint"],
+        )
+
+    def run_probe(self, kind: str, timeout_seconds: float) -> ProbeResult:
+        item = self.fixture["probes"].get(kind)
+        if item is None:
+            raise HarnessFailure(f"fixture has no {kind} probe")
+        duration = float(item["duration_seconds"])
+        if item.get("raise"):
+            raise HarnessFailure(item["raise"])
+        if duration > timeout_seconds:
+            self._time += timeout_seconds
+            raise TimeoutError(f"{kind} replay exceeded probe budget")
+        started = self.utc_now()
+        self._time += duration
+        finished = self.utc_now()
+        observations = tuple(
+            RemoteScopeObservation(
+                probe_kind=value.get("probe_kind", kind),
+                statement_id=value.get("statement_id", item["statement_id"]),
+                query_digest=value.get("query_digest", item["query_digest"]),
+                coordinator_cn=value.get("coordinator_cn", item["coordinator_cn"]),
+                remote_cn=value["remote_cn"],
+                endpoint=value["endpoint"],
+                first_observed_at_utc=value.get("first_observed_at_utc", started),
+                last_observed_at_utc=value.get("last_observed_at_utc", finished),
+                source_kind=value.get("source_kind", "query_trace"),
+            )
+            for value in item.get("remote_observations", [])
+        )
+        artifacts = tuple(
+            SourceArtifact(value["logical_name"], value["content"].encode("utf-8"))
+            for value in item.get("source_artifacts", [])
+        )
+        return ProbeResult(
+            kind=kind,
+            statement_id=item["statement_id"],
+            query_digest=item["query_digest"],
+            started_at_utc=started,
+            finished_at_utc=finished,
+            coordinator_cn=item["coordinator_cn"],
+            outcome=item["outcome"],
+            duration_seconds=duration,
+            consistency_ok=item.get("consistency_ok"),
+            error_class=item.get("error_class"),
+            remote_observations=observations,
+            source_artifacts=artifacts,
+        )
+
+    def inject_fault(self, deadline: float) -> FaultReceipt:
+        del deadline
+        item = self.fixture["fault"]
+        self._time += float(item.get("duration_seconds", 0))
+        return FaultReceipt(
+            target_cn=item["target_cn"],
+            endpoint=item["endpoint"],
+            started_at_utc=self.utc_now(),
+        )
+
+    def observe_topology(self, deadline: float) -> TopologyObservation:
+        del deadline
+        items = self.fixture["topology"]
+        if self._topology_index >= len(items):
+            raise HarnessFailure("topology replay was exhausted")
+        item = items[self._topology_index]
+        self._topology_index += 1
+        self._time = max(self._time, float(item["at_seconds"]))
+        return TopologyObservation(
+            observed_at_utc=self.utc_now(),
+            replacement_ready=bool(item["replacement_ready"]),
+            old_member_visible=bool(item["old_member_visible"]),
+        )
+
+    def wait(self, seconds: float, deadline: float) -> None:
+        if self._time + seconds > deadline:
+            self._time = deadline
+        else:
+            self._time += seconds
+
+    def cleanup(self, deadline: float) -> CleanupReceipt:
+        del deadline
+        self.cleanup_calls += 1
+        item = self.fixture.get("cleanup", {"ok": True})
+        self._time += float(item.get("duration_seconds", 0))
+        return CleanupReceipt(
+            ok=bool(item["ok"]),
+            finished_at_utc=self.utc_now(),
+            detail=item.get("detail", ""),
+        )

--- a/bounded_recovery/scenario.py
+++ b/bounded_recovery/scenario.py
@@ -282,6 +282,7 @@ class BoundedRecoveryScenario:
             raise HarnessFailure(f"driver returned {probe.kind} for {kind}")
         if probe.duration_seconds < 0 or probe.duration_seconds > budget:
             raise HarnessFailure(f"{kind} probe exceeded its bounded budget")
+        self._validate_probe_outcome(probe)
         assert self.deployment is not None
         witness = build_remote_execution_witness(
             probe_kind=kind,
@@ -314,15 +315,36 @@ class BoundedRecoveryScenario:
         self.probes.append(record)
         return record
 
+    def _validate_probe_outcome(self, probe: ProbeResult) -> None:
+        if probe.outcome == "success":
+            if type(probe.consistency_ok) is not bool or probe.error_class is not None:
+                raise ContractError("success probe outcome tuple is invalid")
+            return
+        if probe.outcome == "retriable_error":
+            if (
+                probe.consistency_ok is not None
+                or type(probe.error_class) is not str
+                or probe.error_class not in CONTRACT_ALLOWED_RETRIABLE_ERRORS
+                or probe.error_class not in self.config.allowed_retriable_errors
+            ):
+                raise ContractError("retriable probe outcome tuple is invalid")
+            return
+        raise ContractError("probe outcome is outside the contract")
+
     def _probe_contract_passes(self, probe: dict[str, Any], *, final: bool) -> bool:
         if probe["remote_execution_witness"]["witness_state"] != "verified":
             return False
         if final:
-            return probe["outcome"] == "success" and probe["consistency_ok"] is True
+            return (
+                probe["outcome"] == "success"
+                and probe["consistency_ok"] is True
+                and probe["error_class"] is None
+            )
         if probe["outcome"] == "success":
-            return probe["consistency_ok"] is True
+            return probe["consistency_ok"] is True and probe["error_class"] is None
         return (
             probe["outcome"] == "retriable_error"
+            and probe["consistency_ok"] is None
             and probe["error_class"] in self.config.allowed_retriable_errors
         )
 

--- a/bounded_recovery/scenario.py
+++ b/bounded_recovery/scenario.py
@@ -1,0 +1,425 @@
+"""Single-deadline state machine for the bounded multi-CN recovery contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Callable, Protocol
+
+from .contract import (
+    ContractError,
+    RemoteScopeObservation,
+    SourceArtifact,
+    build_remote_execution_witness,
+    canonical_digest,
+    parse_utc,
+    require_digest,
+    require_revision,
+    stable_identity,
+)
+
+
+TARGET_REF = "target/chaos/multi-cn-bounded-recovery-v1"
+TEST_CONTRACT_ID = "contract/chaos/multi-cn-stale-topology-bounded/v1"
+
+
+class HarnessFailure(RuntimeError):
+    """The observer/checker failed, so product behavior is not evaluable."""
+
+
+class CoverageNotExercised(RuntimeError):
+    """A safe precondition was absent, so no fault may be injected."""
+
+
+class ScenarioDriver(Protocol):
+    def monotonic(self) -> float: ...
+
+    def utc_now(self) -> str: ...
+
+    def preflight(self, deadline: float) -> "DeploymentObservation": ...
+
+    def run_probe(self, kind: str, timeout_seconds: float) -> "ProbeResult": ...
+
+    def inject_fault(self, deadline: float) -> "FaultReceipt": ...
+
+    def observe_topology(self, deadline: float) -> "TopologyObservation": ...
+
+    def wait(self, seconds: float, deadline: float) -> None: ...
+
+    def cleanup(self, deadline: float) -> "CleanupReceipt": ...
+
+
+@dataclass(frozen=True)
+class ScenarioConfig:
+    candidate_revision: str
+    cluster_uid: str
+    generation: str
+    expected_image_digest: str
+    scenario_budget_seconds: float = 1800.0
+    probe_budget_seconds: float = 30.0
+    poll_interval_seconds: float = 1.0
+    allowed_retriable_errors: tuple[str, ...] = (
+        "backend_create_timeout",
+        "retryable_topology_change",
+    )
+
+    def validate(self) -> None:
+        require_revision(self.candidate_revision)
+        require_digest(self.expected_image_digest, "expected_image_digest")
+        if not self.cluster_uid or not self.generation:
+            raise ContractError("cluster identity and generation are required")
+        if self.scenario_budget_seconds <= 0:
+            raise ContractError("scenario budget must be positive")
+        if not 0 < self.probe_budget_seconds <= self.scenario_budget_seconds:
+            raise ContractError("probe budget must fit inside the scenario budget")
+        if not 0 < self.poll_interval_seconds <= self.probe_budget_seconds:
+            raise ContractError("poll interval must fit inside the probe budget")
+
+
+@dataclass(frozen=True)
+class DeploymentObservation:
+    cluster_uid: str
+    generation: str
+    image_digests: tuple[str, ...]
+    fault_target_cn: str
+    fault_endpoint: str
+
+
+@dataclass(frozen=True)
+class FaultReceipt:
+    target_cn: str
+    endpoint: str
+    started_at_utc: str
+
+
+@dataclass(frozen=True)
+class TopologyObservation:
+    observed_at_utc: str
+    replacement_ready: bool
+    old_member_visible: bool
+
+
+@dataclass(frozen=True)
+class CleanupReceipt:
+    ok: bool
+    finished_at_utc: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    kind: str
+    statement_id: str
+    query_digest: str
+    started_at_utc: str
+    finished_at_utc: str
+    coordinator_cn: str
+    outcome: str
+    duration_seconds: float
+    consistency_ok: bool | None
+    error_class: str | None = None
+    remote_observations: tuple[RemoteScopeObservation, ...] = field(default_factory=tuple)
+    source_artifacts: tuple[SourceArtifact, ...] = field(default_factory=tuple)
+
+
+class BoundedRecoveryScenario:
+    def __init__(
+        self,
+        config: ScenarioConfig,
+        driver: ScenarioDriver,
+        *,
+        attempt_id: str,
+        on_partial: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        config.validate()
+        if not attempt_id:
+            raise ContractError("attempt_id is required")
+        self.config = config
+        self.driver = driver
+        self.attempt_id = attempt_id
+        self.on_partial = on_partial or (lambda _: None)
+        self.started = driver.monotonic()
+        self.deadline = self.started + config.scenario_budget_seconds
+        self.probes: list[dict[str, Any]] = []
+        deadline_utc = parse_utc(driver.utc_now()) + timedelta(
+            seconds=config.scenario_budget_seconds
+        )
+        self.timeline: dict[str, str] = {
+            "fault_start": "not_started",
+            "replacement_ready_at": "unknown",
+            "stale_window_observed_at": "unknown",
+            "old_member_evicted_at": "unknown",
+            "stale_probe_started_at": "not_exercised",
+            "stale_probe_finished_at": "not_exercised",
+            "recovery_probe_started_at": "not_started",
+            "recovery_probe_finished_at": "not_started",
+            "recovery_frontier": "unknown",
+            "scenario_deadline": deadline_utc.isoformat(timespec="microseconds").replace(
+                "+00:00", "Z"
+            ),
+        }
+        self.failure_domain: str | None = None
+        self.failure_reason: str | None = None
+        self.evidence_validity = "partial"
+        self.product_result = "not_evaluated"
+        self.exercise_state = "not_exercised"
+        self.cleanup_receipt: CleanupReceipt | None = None
+        self.fault_receipt: FaultReceipt | None = None
+        self.deployment: DeploymentObservation | None = None
+
+    def _remaining(self) -> float:
+        return max(0.0, self.deadline - self.driver.monotonic())
+
+    def _require_remaining(self, stage: str) -> float:
+        remaining = self._remaining()
+        if remaining <= 0:
+            raise TimeoutError(f"scenario deadline exhausted during {stage}")
+        return remaining
+
+    def _emit_partial(self, stage: str) -> None:
+        partial = self._result(raw_conclusion="unknown", execution_state="started")
+        partial.pop("content_digest")
+        partial["stage"] = stage
+        partial["content_digest"] = canonical_digest(partial)
+        self.on_partial(partial)
+
+    def _validate_deployment(self, value: DeploymentObservation) -> None:
+        if value.cluster_uid != self.config.cluster_uid:
+            raise ContractError("deployment cluster_uid mismatch")
+        if value.generation != self.config.generation:
+            raise ContractError("deployment generation mismatch")
+        if not value.fault_target_cn or not value.fault_endpoint:
+            raise ContractError("fault target identity is incomplete")
+        observed = set(value.image_digests)
+        if observed != {self.config.expected_image_digest}:
+            raise ContractError("deployment image digests are mixed or unexpected")
+
+    def _run_probe(self, kind: str) -> dict[str, Any]:
+        remaining = self._require_remaining(kind)
+        budget = min(self.config.probe_budget_seconds, remaining)
+        probe = self.driver.run_probe(kind, budget)
+        if probe.kind != kind:
+            raise HarnessFailure(f"driver returned {probe.kind} for {kind}")
+        if probe.duration_seconds < 0 or probe.duration_seconds > budget:
+            raise HarnessFailure(f"{kind} probe exceeded its bounded budget")
+        assert self.deployment is not None
+        witness = build_remote_execution_witness(
+            probe_kind=kind,
+            candidate_revision=self.config.candidate_revision,
+            cluster_uid=self.config.cluster_uid,
+            generation=self.config.generation,
+            coordinator_cn=probe.coordinator_cn,
+            statement_id=probe.statement_id,
+            probe_query_digest=probe.query_digest,
+            started_at_utc=probe.started_at_utc,
+            finished_at_utc=probe.finished_at_utc,
+            fault_target_cn=self.deployment.fault_target_cn,
+            fault_endpoint=self.deployment.fault_endpoint,
+            observations=probe.remote_observations,
+            source_artifacts=probe.source_artifacts,
+        )
+        record = {
+            "probe_kind": kind,
+            "statement_id": probe.statement_id,
+            "query_digest": probe.query_digest,
+            "started_at_utc": probe.started_at_utc,
+            "finished_at_utc": probe.finished_at_utc,
+            "duration_seconds": probe.duration_seconds,
+            "outcome": probe.outcome,
+            "consistency_ok": probe.consistency_ok,
+            "error_class": probe.error_class,
+            "remote_execution_witness": witness,
+            "remote_execution_witness_digest": canonical_digest(witness),
+        }
+        self.probes.append(record)
+        return record
+
+    def _probe_contract_passes(self, probe: dict[str, Any], *, final: bool) -> bool:
+        if probe["remote_execution_witness"]["witness_state"] != "verified":
+            return False
+        if final:
+            return probe["outcome"] == "success" and probe["consistency_ok"] is True
+        if probe["outcome"] == "success":
+            return probe["consistency_ok"] is True
+        return (
+            probe["outcome"] == "retriable_error"
+            and probe["error_class"] in self.config.allowed_retriable_errors
+        )
+
+    def run(self) -> dict[str, Any]:
+        raw_conclusion = "success"
+        execution_state = "completed"
+        stale_observed = False
+        try:
+            self.deployment = self.driver.preflight(self.deadline)
+            self._validate_deployment(self.deployment)
+            self._emit_partial("preflight")
+
+            baseline = self._run_probe("baseline")
+            self._emit_partial("baseline")
+            if not self._probe_contract_passes(baseline, final=True):
+                self.evidence_validity = (
+                    "mismatch"
+                    if baseline["remote_execution_witness"]["witness_state"] == "mismatch"
+                    else "partial"
+                )
+                self.failure_reason = "baseline remote execution was not verified"
+                raise CoverageNotExercised(self.failure_reason)
+
+            self.fault_receipt = self.driver.inject_fault(self.deadline)
+            if (
+                self.fault_receipt.target_cn != self.deployment.fault_target_cn
+                or self.fault_receipt.endpoint != self.deployment.fault_endpoint
+            ):
+                raise ContractError("fault receipt does not match the preflight target")
+            self.timeline["fault_start"] = self.fault_receipt.started_at_utc
+            self._emit_partial("fault_injected")
+
+            while True:
+                self._require_remaining("stale topology observation")
+                topology = self.driver.observe_topology(self.deadline)
+                if topology.replacement_ready and self.timeline["replacement_ready_at"] == "unknown":
+                    self.timeline["replacement_ready_at"] = topology.observed_at_utc
+                if topology.replacement_ready and topology.old_member_visible:
+                    stale_observed = True
+                    self.timeline["stale_window_observed_at"] = topology.observed_at_utc
+                    self.exercise_state = "exercised"
+                    stale = self._run_probe("stale_window")
+                    self.timeline["stale_probe_started_at"] = stale["started_at_utc"]
+                    self.timeline["stale_probe_finished_at"] = stale["finished_at_utc"]
+                    self._emit_partial("stale_probe")
+                    break
+                if not topology.old_member_visible:
+                    self.timeline["old_member_evicted_at"] = topology.observed_at_utc
+                    break
+                self.driver.wait(
+                    min(self.config.poll_interval_seconds, self._require_remaining("stale wait")),
+                    self.deadline,
+                )
+
+            if self.timeline["old_member_evicted_at"] == "unknown":
+                while True:
+                    self._require_remaining("old member eviction")
+                    topology = self.driver.observe_topology(self.deadline)
+                    if not topology.old_member_visible:
+                        self.timeline["old_member_evicted_at"] = topology.observed_at_utc
+                        break
+                    self.driver.wait(
+                        min(self.config.poll_interval_seconds, self._require_remaining("eviction wait")),
+                        self.deadline,
+                    )
+
+            recovery = self._run_probe("post_eviction")
+            self.timeline["recovery_probe_started_at"] = recovery["started_at_utc"]
+            self.timeline["recovery_probe_finished_at"] = recovery["finished_at_utc"]
+            self.timeline["recovery_frontier"] = recovery["finished_at_utc"]
+            self._emit_partial("post_eviction_probe")
+
+            all_witnesses_verified = all(
+                item["remote_execution_witness"]["witness_state"] == "verified"
+                for item in self.probes
+            )
+            stale = next(
+                (item for item in self.probes if item["probe_kind"] == "stale_window"),
+                None,
+            )
+            if not stale_observed or stale is None or not all_witnesses_verified:
+                self.evidence_validity = "partial"
+                self.product_result = "not_evaluated"
+                self.exercise_state = "not_exercised"
+                self.failure_reason = "stale window or remote scope was not exercised"
+            elif not self._probe_contract_passes(stale, final=False):
+                self.evidence_validity = "valid"
+                self.product_result = "failed"
+                self.failure_domain = "product"
+                self.failure_reason = "stale-window probe violated the bounded recovery contract"
+                raw_conclusion = "failure"
+            elif not self._probe_contract_passes(recovery, final=True):
+                self.evidence_validity = "valid"
+                self.product_result = "failed"
+                self.failure_domain = "product"
+                self.failure_reason = "post-eviction consistency or recovery probe failed"
+                raw_conclusion = "failure"
+            else:
+                self.evidence_validity = "valid"
+                self.product_result = "passed"
+                self.exercise_state = "exercised"
+        except ContractError as exc:
+            self.evidence_validity = "mismatch"
+            self.product_result = "not_evaluated"
+            self.failure_domain = "infra"
+            self.failure_reason = str(exc)
+            raw_conclusion = "failure"
+            execution_state = "blocked" if self.fault_receipt is None else "completed"
+        except CoverageNotExercised as exc:
+            self.product_result = "not_evaluated"
+            self.exercise_state = "not_exercised"
+            self.failure_reason = str(exc)
+        except HarnessFailure as exc:
+            self.evidence_validity = "partial"
+            self.product_result = "not_evaluated"
+            self.failure_domain = "harness"
+            self.failure_reason = str(exc)
+            raw_conclusion = "failure"
+        except TimeoutError as exc:
+            self.evidence_validity = "valid" if self.fault_receipt is not None else "partial"
+            self.product_result = "failed" if self.fault_receipt is not None else "not_evaluated"
+            self.failure_domain = "product" if self.fault_receipt is not None else "infra"
+            self.failure_reason = str(exc)
+            raw_conclusion = "timed_out"
+        except Exception as exc:
+            self.evidence_validity = "partial"
+            self.product_result = "not_evaluated"
+            self.failure_domain = "harness"
+            self.failure_reason = f"unexpected harness failure: {exc}"
+            raw_conclusion = "failure"
+        finally:
+            try:
+                self.cleanup_receipt = self.driver.cleanup(self.deadline)
+                if not self.cleanup_receipt.ok:
+                    self.evidence_validity = "infra_invalid"
+                    self.product_result = "not_evaluated"
+                    self.failure_domain = "infra"
+                    self.failure_reason = "cleanup failed: " + self.cleanup_receipt.detail
+                    raw_conclusion = "failure"
+            except Exception as exc:  # cleanup must never hide the primary state
+                self.evidence_validity = "infra_invalid"
+                self.product_result = "not_evaluated"
+                self.failure_domain = "infra"
+                self.failure_reason = f"cleanup raised: {exc}"
+                raw_conclusion = "failure"
+
+        return self._result(raw_conclusion=raw_conclusion, execution_state=execution_state)
+
+    def _result(self, *, raw_conclusion: str, execution_state: str) -> dict[str, Any]:
+        cleanup = None
+        if self.cleanup_receipt is not None:
+            cleanup = {
+                "ok": self.cleanup_receipt.ok,
+                "finished_at_utc": self.cleanup_receipt.finished_at_utc,
+                "detail": self.cleanup_receipt.detail,
+            }
+        result = {
+            "format": "recovery-contract-result/v1",
+            "target_ref": TARGET_REF,
+            "test_contract_id": TEST_CONTRACT_ID,
+            "attempt_id": self.attempt_id,
+            "candidate_revision": self.config.candidate_revision,
+            "cluster": {
+                "cluster_uid": stable_identity(self.config.cluster_uid),
+                "generation": self.config.generation,
+                "expected_image_digest": self.config.expected_image_digest,
+            },
+            "execution_state": execution_state,
+            "raw_conclusion": raw_conclusion,
+            "evidence_validity": self.evidence_validity,
+            "product_result": self.product_result,
+            "failure_domain": self.failure_domain,
+            "failure_reason": self.failure_reason,
+            "oracle_observation": {"exercise_state": self.exercise_state},
+            "timeline": dict(self.timeline),
+            "probes": list(self.probes),
+            "cleanup": cleanup,
+        }
+        result["content_digest"] = canonical_digest(result)
+        return result

--- a/bounded_recovery/scenario.py
+++ b/bounded_recovery/scenario.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Callable, Protocol
@@ -21,6 +22,38 @@ from .contract import (
 
 TARGET_REF = "target/chaos/multi-cn-bounded-recovery-v1"
 TEST_CONTRACT_ID = "contract/chaos/multi-cn-stale-topology-bounded/v1"
+MAX_EXTERNAL_DIAGNOSTIC_CHARS = 4096
+EXTERNAL_DIAGNOSTIC_CODES = frozenset(
+    {
+        "cleanup_detail",
+        "cleanup_failed",
+        "cleanup_exception",
+        "contract_error",
+        "coverage_not_exercised",
+        "harness_failure",
+        "scenario_timeout",
+        "unexpected_harness_failure",
+    }
+)
+
+
+def _bounded_external_diagnostic(code: str, value: Any) -> str:
+    """Serialize untrusted diagnostics as one allowlisted code and bounded digest."""
+
+    if code not in EXTERNAL_DIAGNOSTIC_CODES:
+        raise AssertionError(f"diagnostic code is not allowlisted: {code}")
+    try:
+        source = str(value)
+    except Exception:
+        source = "unprintable-external-diagnostic"
+    hasher = hashlib.sha256()
+    for offset in range(0, len(source), MAX_EXTERNAL_DIAGNOSTIC_CHARS):
+        hasher.update(
+            source[offset : offset + MAX_EXTERNAL_DIAGNOSTIC_CHARS].encode("utf-8")
+        )
+    digest = "sha256:" + hasher.hexdigest()
+    truncated = "true" if len(source) > MAX_EXTERNAL_DIAGNOSTIC_CHARS else "false"
+    return f"{code}; diagnostic_digest={digest}; source_truncated={truncated}"
 
 
 class HarnessFailure(RuntimeError):
@@ -194,6 +227,30 @@ class BoundedRecoveryScenario:
         if observed != {self.config.expected_image_digest}:
             raise ContractError("deployment image digests are mixed or unexpected")
 
+    @staticmethod
+    def _validate_topology(value: TopologyObservation) -> None:
+        parse_utc(value.observed_at_utc)
+        if type(value.replacement_ready) is not bool:
+            raise ContractError("topology replacement_ready must be a boolean")
+        if type(value.old_member_visible) is not bool:
+            raise ContractError("topology old_member_visible must be a boolean")
+
+    @staticmethod
+    def _sanitize_cleanup(value: CleanupReceipt) -> CleanupReceipt:
+        if type(value.ok) is not bool:
+            raise ContractError("cleanup ok must be a boolean")
+        parse_utc(value.finished_at_utc)
+        detail = (
+            _bounded_external_diagnostic("cleanup_detail", value.detail)
+            if value.detail
+            else ""
+        )
+        return CleanupReceipt(
+            ok=value.ok,
+            finished_at_utc=value.finished_at_utc,
+            detail=detail,
+        )
+
     def _run_probe(self, kind: str) -> dict[str, Any]:
         remaining = self._require_remaining(kind)
         budget = min(self.config.probe_budget_seconds, remaining)
@@ -278,6 +335,7 @@ class BoundedRecoveryScenario:
             while True:
                 self._require_remaining("stale topology observation")
                 topology = self.driver.observe_topology(self.deadline)
+                self._validate_topology(topology)
                 if topology.replacement_ready and self.timeline["replacement_ready_at"] == "unknown":
                     self.timeline["replacement_ready_at"] = topology.observed_at_utc
                 if topology.replacement_ready and topology.old_member_visible:
@@ -301,6 +359,7 @@ class BoundedRecoveryScenario:
                 while True:
                     self._require_remaining("old member eviction")
                     topology = self.driver.observe_topology(self.deadline)
+                    self._validate_topology(topology)
                     if not topology.old_member_visible:
                         self.timeline["old_member_evicted_at"] = topology.observed_at_utc
                         break
@@ -348,45 +407,60 @@ class BoundedRecoveryScenario:
             self.evidence_validity = "mismatch"
             self.product_result = "not_evaluated"
             self.failure_domain = "infra"
-            self.failure_reason = str(exc)
+            self.failure_reason = _bounded_external_diagnostic("contract_error", exc)
             raw_conclusion = "failure"
             execution_state = "blocked" if self.fault_receipt is None else "completed"
         except CoverageNotExercised as exc:
             self.product_result = "not_evaluated"
             self.exercise_state = "not_exercised"
-            self.failure_reason = str(exc)
+            self.failure_reason = _bounded_external_diagnostic(
+                "coverage_not_exercised", exc
+            )
         except HarnessFailure as exc:
             self.evidence_validity = "partial"
             self.product_result = "not_evaluated"
             self.failure_domain = "harness"
-            self.failure_reason = str(exc)
+            self.failure_reason = _bounded_external_diagnostic("harness_failure", exc)
             raw_conclusion = "failure"
         except TimeoutError as exc:
             self.evidence_validity = "valid" if self.fault_receipt is not None else "partial"
             self.product_result = "failed" if self.fault_receipt is not None else "not_evaluated"
             self.failure_domain = "product" if self.fault_receipt is not None else "infra"
-            self.failure_reason = str(exc)
+            self.failure_reason = _bounded_external_diagnostic("scenario_timeout", exc)
             raw_conclusion = "timed_out"
         except Exception as exc:
             self.evidence_validity = "partial"
             self.product_result = "not_evaluated"
             self.failure_domain = "harness"
-            self.failure_reason = f"unexpected harness failure: {exc}"
+            self.failure_reason = _bounded_external_diagnostic(
+                "unexpected_harness_failure", exc
+            )
             raw_conclusion = "failure"
         finally:
             try:
-                self.cleanup_receipt = self.driver.cleanup(self.deadline)
-                if not self.cleanup_receipt.ok:
+                raw_cleanup = self.driver.cleanup(self.deadline)
+                self.cleanup_receipt = self._sanitize_cleanup(raw_cleanup)
+                if self.driver.monotonic() > self.deadline:
                     self.evidence_validity = "infra_invalid"
                     self.product_result = "not_evaluated"
                     self.failure_domain = "infra"
-                    self.failure_reason = "cleanup failed: " + self.cleanup_receipt.detail
+                    self.failure_reason = "cleanup_deadline_exceeded"
+                    raw_conclusion = "failure"
+                elif not self.cleanup_receipt.ok:
+                    self.evidence_validity = "infra_invalid"
+                    self.product_result = "not_evaluated"
+                    self.failure_domain = "infra"
+                    self.failure_reason = _bounded_external_diagnostic(
+                        "cleanup_failed", raw_cleanup.detail
+                    )
                     raw_conclusion = "failure"
             except Exception as exc:  # cleanup must never hide the primary state
                 self.evidence_validity = "infra_invalid"
                 self.product_result = "not_evaluated"
                 self.failure_domain = "infra"
-                self.failure_reason = f"cleanup raised: {exc}"
+                self.failure_reason = _bounded_external_diagnostic(
+                    "cleanup_exception", exc
+                )
                 raw_conclusion = "failure"
 
         return self._result(raw_conclusion=raw_conclusion, execution_state=execution_state)

--- a/bounded_recovery/scenario.py
+++ b/bounded_recovery/scenario.py
@@ -22,6 +22,10 @@ from .contract import (
 
 TARGET_REF = "target/chaos/multi-cn-bounded-recovery-v1"
 TEST_CONTRACT_ID = "contract/chaos/multi-cn-stale-topology-bounded/v1"
+CONTRACT_ALLOWED_RETRIABLE_ERRORS = (
+    "backend_create_timeout",
+    "retryable_topology_change",
+)
 MAX_EXTERNAL_DIAGNOSTIC_CHARS = 4096
 EXTERNAL_DIAGNOSTIC_CODES = frozenset(
     {
@@ -91,10 +95,7 @@ class ScenarioConfig:
     scenario_budget_seconds: float = 1800.0
     probe_budget_seconds: float = 30.0
     poll_interval_seconds: float = 1.0
-    allowed_retriable_errors: tuple[str, ...] = (
-        "backend_create_timeout",
-        "retryable_topology_change",
-    )
+    allowed_retriable_errors: tuple[str, ...] = CONTRACT_ALLOWED_RETRIABLE_ERRORS
 
     def validate(self) -> None:
         require_revision(self.candidate_revision)
@@ -174,7 +175,8 @@ class BoundedRecoveryScenario:
         self.started = driver.monotonic()
         self.deadline = self.started + config.scenario_budget_seconds
         self.probes: list[dict[str, Any]] = []
-        deadline_utc = parse_utc(driver.utc_now()) + timedelta(
+        self.started_at_utc = parse_utc(driver.utc_now())
+        self.deadline_utc = self.started_at_utc + timedelta(
             seconds=config.scenario_budget_seconds
         )
         self.timeline: dict[str, str] = {
@@ -187,9 +189,9 @@ class BoundedRecoveryScenario:
             "recovery_probe_started_at": "not_started",
             "recovery_probe_finished_at": "not_started",
             "recovery_frontier": "unknown",
-            "scenario_deadline": deadline_utc.isoformat(timespec="microseconds").replace(
-                "+00:00", "Z"
-            ),
+            "scenario_deadline": self.deadline_utc.isoformat(
+                timespec="microseconds"
+            ).replace("+00:00", "Z"),
         }
         self.failure_domain: str | None = None
         self.failure_reason: str | None = None
@@ -234,6 +236,27 @@ class BoundedRecoveryScenario:
             raise ContractError("topology replacement_ready must be a boolean")
         if type(value.old_member_visible) is not bool:
             raise ContractError("topology old_member_visible must be a boolean")
+
+    def _validate_fault_receipt(
+        self, value: FaultReceipt, *, baseline_finished_at_utc: str
+    ) -> None:
+        assert self.deployment is not None
+        if (
+            value.target_cn != self.deployment.fault_target_cn
+            or value.endpoint != self.deployment.fault_endpoint
+        ):
+            raise ContractError("fault receipt does not match the preflight target")
+        baseline_finished = parse_utc(baseline_finished_at_utc)
+        fault_started = parse_utc(value.started_at_utc)
+        observed_now = parse_utc(self.driver.utc_now())
+        if not (
+            self.started_at_utc
+            <= baseline_finished
+            <= fault_started
+            <= observed_now
+            <= self.deadline_utc
+        ):
+            raise ContractError("fault receipt timestamp is outside the scenario interval")
 
     @staticmethod
     def _sanitize_cleanup(value: CleanupReceipt) -> CleanupReceipt:
@@ -323,12 +346,12 @@ class BoundedRecoveryScenario:
                 self.failure_reason = "baseline remote execution was not verified"
                 raise CoverageNotExercised(self.failure_reason)
 
+            self._require_remaining("fault injection")
             self.fault_receipt = self.driver.inject_fault(self.deadline)
-            if (
-                self.fault_receipt.target_cn != self.deployment.fault_target_cn
-                or self.fault_receipt.endpoint != self.deployment.fault_endpoint
-            ):
-                raise ContractError("fault receipt does not match the preflight target")
+            self._validate_fault_receipt(
+                self.fault_receipt,
+                baseline_finished_at_utc=baseline["finished_at_utc"],
+            )
             self.timeline["fault_start"] = self.fault_receipt.started_at_utc
             self._emit_partial("fault_injected")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bounded recovery contract."""

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+from bounded_recovery.campaign import evaluate_campaign
+from bounded_recovery.cli import main
+from bounded_recovery.contract import ContractError, canonical_digest
+from bounded_recovery.replay import ReplayDriver
+from bounded_recovery.scenario import BoundedRecoveryScenario, ScenarioConfig
+
+
+CANDIDATE = "1" * 40
+IMAGE_DIGEST = "sha256:" + "2" * 64
+QUERY_DIGESTS = {
+    "baseline": "sha256:" + "3" * 64,
+    "stale_window": "sha256:" + "4" * 64,
+    "post_eviction": "sha256:" + "5" * 64,
+}
+RAW_DEAD_ENDPOINT = "10.10.211.174:6002"
+
+
+def valid_fixture(attempt_id: str = "attempt-1") -> dict:
+    probes = {}
+    for index, kind in enumerate(("baseline", "stale_window", "post_eviction"), 1):
+        statement_id = f"00000000-0000-0000-0000-{index:012d}"
+        coordinator = "cn-survivor"
+        probes[kind] = {
+            "statement_id": statement_id,
+            "query_digest": QUERY_DIGESTS[kind],
+            "coordinator_cn": coordinator,
+            "duration_seconds": 0.25,
+            "outcome": "success",
+            "consistency_ok": True,
+            "remote_observations": [
+                {
+                    "remote_cn": "cn-replacement" if kind != "baseline" else "cn-target",
+                    "endpoint": (
+                        "10.10.187.82:6002" if kind != "baseline" else RAW_DEAD_ENDPOINT
+                    ),
+                    "source_kind": "bounded_cn_log",
+                }
+            ],
+            "source_artifacts": [
+                {
+                    "logical_name": f"{kind}-cn-log.json",
+                    "content": (
+                        f"bounded trace statement_id={statement_id} "
+                        f"query_digest={QUERY_DIGESTS[kind]}"
+                    ),
+                }
+            ],
+        }
+    return {
+        "attempt_id": attempt_id,
+        "started_at_utc": "2026-08-24T02:30:00.000000Z",
+        "config": {
+            "candidate_revision": CANDIDATE,
+            "cluster_uid": "cluster-generation-owner",
+            "generation": "generation-7",
+            "expected_image_digest": IMAGE_DIGEST,
+            "scenario_budget_seconds": 30,
+            "probe_budget_seconds": 2,
+            "poll_interval_seconds": 0.5,
+        },
+        "deployment": {
+            "cluster_uid": "cluster-generation-owner",
+            "generation": "generation-7",
+            "image_digests": [IMAGE_DIGEST],
+            "fault_target_cn": "cn-target",
+            "fault_endpoint": RAW_DEAD_ENDPOINT,
+        },
+        "fault": {
+            "target_cn": "cn-target",
+            "endpoint": RAW_DEAD_ENDPOINT,
+            "duration_seconds": 0.1,
+        },
+        "topology": [
+            {
+                "at_seconds": 1.0,
+                "replacement_ready": False,
+                "old_member_visible": True,
+            },
+            {
+                "at_seconds": 2.0,
+                "replacement_ready": True,
+                "old_member_visible": True,
+            },
+            {
+                "at_seconds": 3.0,
+                "replacement_ready": True,
+                "old_member_visible": False,
+            },
+        ],
+        "probes": probes,
+        "cleanup": {"ok": True, "duration_seconds": 0.1},
+    }
+
+
+def run_fixture(fixture: dict) -> tuple[dict, ReplayDriver, list[dict]]:
+    config = ScenarioConfig(**fixture["config"])
+    driver = ReplayDriver(fixture)
+    partials = []
+    result = BoundedRecoveryScenario(
+        config,
+        driver,
+        attempt_id=fixture["attempt_id"],
+        on_partial=partials.append,
+    ).run()
+    return result, driver, partials
+
+
+class BoundedRecoveryScenarioTest(unittest.TestCase):
+    def test_success_requires_both_fault_probes_and_three_verified_witnesses(self):
+        result, driver, partials = run_fixture(valid_fixture())
+
+        self.assertEqual("passed", result["product_result"])
+        self.assertEqual("valid", result["evidence_validity"])
+        self.assertEqual("exercised", result["oracle_observation"]["exercise_state"])
+        self.assertEqual(
+            ["baseline", "stale_window", "post_eviction"],
+            [probe["probe_kind"] for probe in result["probes"]],
+        )
+        self.assertTrue(
+            all(
+                probe["remote_execution_witness"]["witness_state"] == "verified"
+                for probe in result["probes"]
+            )
+        )
+        self.assertEqual(1, driver.cleanup_calls)
+        self.assertGreaterEqual(len(partials), 5)
+        self.assertNotIn(RAW_DEAD_ENDPOINT, json.dumps(result, sort_keys=True))
+        without_digest = dict(result)
+        digest = without_digest.pop("content_digest")
+        self.assertEqual(digest, canonical_digest(without_digest))
+
+    def test_stale_window_miss_is_not_exercised_not_passed(self):
+        fixture = valid_fixture()
+        fixture["topology"] = [
+            {
+                "at_seconds": 1.0,
+                "replacement_ready": False,
+                "old_member_visible": True,
+            },
+            {
+                "at_seconds": 2.0,
+                "replacement_ready": True,
+                "old_member_visible": False,
+            },
+        ]
+        result, driver, _ = run_fixture(fixture)
+
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual("not_exercised", result["oracle_observation"]["exercise_state"])
+        self.assertEqual(["baseline", "post_eviction"], [p["probe_kind"] for p in result["probes"]])
+        self.assertEqual(1, driver.cleanup_calls)
+
+    def test_mixed_image_preflight_blocks_before_fault(self):
+        fixture = valid_fixture()
+        fixture["deployment"]["image_digests"].append("sha256:" + "9" * 64)
+        result, driver, partials = run_fixture(fixture)
+
+        self.assertEqual("blocked", result["execution_state"])
+        self.assertEqual("mismatch", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual([], result["probes"])
+        self.assertEqual([], partials)
+        self.assertEqual(1, driver.cleanup_calls)
+
+    def test_wrong_statement_witness_is_mismatch_and_fault_is_not_injected(self):
+        fixture = valid_fixture()
+        fixture["probes"]["baseline"]["remote_observations"][0]["statement_id"] = "wrong"
+        result, driver, _ = run_fixture(fixture)
+
+        self.assertEqual("mismatch", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual("mismatch", result["probes"][0]["remote_execution_witness"]["witness_state"])
+        self.assertEqual("not_started", result["timeline"]["fault_start"])
+        self.assertEqual(1, driver.cleanup_calls)
+
+    def test_probe_without_remote_scope_is_not_observed(self):
+        fixture = valid_fixture()
+        fixture["probes"]["baseline"]["remote_observations"] = []
+        result, _, _ = run_fixture(fixture)
+
+        self.assertEqual("not_observed", result["probes"][0]["remote_execution_witness"]["witness_state"])
+        self.assertEqual("not_evaluated", result["product_result"])
+
+    def test_checker_failure_is_harness_not_product(self):
+        fixture = valid_fixture()
+        fixture["probes"]["stale_window"]["raise"] = "checker crashed"
+        result, driver, _ = run_fixture(fixture)
+
+        self.assertEqual("harness", result["failure_domain"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual("failure", result["raw_conclusion"])
+        self.assertEqual(1, driver.cleanup_calls)
+
+    def test_stale_probe_timeout_is_bounded_product_failure(self):
+        fixture = valid_fixture()
+        fixture["probes"]["stale_window"]["duration_seconds"] = 10
+        result, driver, _ = run_fixture(fixture)
+
+        self.assertEqual("product", result["failure_domain"])
+        self.assertEqual("failed", result["product_result"])
+        self.assertEqual("timed_out", result["raw_conclusion"])
+        self.assertEqual(1, driver.cleanup_calls)
+
+    def test_allowlisted_retriable_stale_failure_can_satisfy_contract(self):
+        fixture = valid_fixture()
+        fixture["probes"]["stale_window"].update(
+            outcome="retriable_error",
+            consistency_ok=None,
+            error_class="backend_create_timeout",
+        )
+        result, _, _ = run_fixture(fixture)
+
+        self.assertEqual("passed", result["product_result"])
+
+    def test_cleanup_failure_invalidates_an_otherwise_passing_attempt(self):
+        fixture = valid_fixture()
+        fixture["cleanup"] = {"ok": False, "detail": "chaos object remained"}
+        result, _, _ = run_fixture(fixture)
+
+        self.assertEqual("infra_invalid", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual("infra", result["failure_domain"])
+
+
+class CampaignTest(unittest.TestCase):
+    def test_exact_twenty_attempt_campaign_passes_without_overwriting_attempts(self):
+        attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
+        result = evaluate_campaign(attempts)
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(20, result["stale_window_exercised"])
+        self.assertEqual(20, len(result["attempts"]))
+        self.assertEqual(20, len({item["content_digest"] for item in result["attempts"]}))
+
+    def test_campaign_preserves_a_not_exercised_attempt_and_fails_gate(self):
+        attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
+        missed = valid_fixture("attempt-07")
+        missed["topology"] = [
+            {
+                "at_seconds": 1.0,
+                "replacement_ready": True,
+                "old_member_visible": False,
+            }
+        ]
+        attempts[7] = run_fixture(missed)[0]
+        result = evaluate_campaign(attempts)
+
+        self.assertFalse(result["passed"])
+        self.assertEqual(19, result["stale_window_exercised"])
+        self.assertEqual({"not_evaluated": 1, "passed": 19}, result["product_result_counts"])
+
+    def test_campaign_rejects_wrong_count_duplicate_ids_and_drift(self):
+        attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
+        with self.assertRaises(ContractError):
+            evaluate_campaign(attempts[:-1])
+        duplicated = deepcopy(attempts)
+        duplicated[1]["attempt_id"] = duplicated[0]["attempt_id"]
+        with self.assertRaises(ContractError):
+            evaluate_campaign(duplicated)
+        drifted = deepcopy(attempts)
+        drifted[2]["candidate_revision"] = "a" * 40
+        with self.assertRaises(ContractError):
+            evaluate_campaign(drifted)
+
+    def test_campaign_rejects_tampered_attempt_even_if_claimed_result_is_green(self):
+        attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
+        attempts[4] = deepcopy(attempts[4])
+        attempts[4]["timeline"]["fault_start"] = "2026-08-24T00:00:00.000000Z"
+        with self.assertRaisesRegex(ContractError, "content digest mismatch"):
+            evaluate_campaign(attempts)
+
+
+class OfflineCliTest(unittest.TestCase):
+    def test_replay_writes_partial_and_final_receipts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture_path = root / "fixture.json"
+            output_path = root / "recovery-contract-result.json"
+            fixture_path.write_text(json.dumps(valid_fixture()), encoding="utf-8")
+
+            self.assertEqual(
+                0,
+                main(
+                    [
+                        "replay",
+                        "--fixture",
+                        str(fixture_path),
+                        "--output",
+                        str(output_path),
+                    ]
+                ),
+            )
+            self.assertTrue(output_path.exists())
+            self.assertTrue((root / "partial-recovery-contract-result.json").exists())
+            self.assertEqual("passed", json.loads(output_path.read_text())["product_result"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -6,14 +6,17 @@ import unittest
 from copy import deepcopy
 from pathlib import Path
 
-from bounded_recovery.campaign import evaluate_campaign
+from bounded_recovery.campaign import evaluate_campaign, validate_attempt_result
 from bounded_recovery.cli import main
 from bounded_recovery.contract import ContractError, canonical_digest
 from bounded_recovery.replay import ReplayDriver
 from bounded_recovery.scenario import (
     BoundedRecoveryScenario,
+    FaultReceipt,
     HarnessFailure,
     ScenarioConfig,
+    TARGET_REF,
+    TEST_CONTRACT_ID,
 )
 
 
@@ -119,6 +122,43 @@ def run_fixture(
     return result, driver, partials
 
 
+def redigest(value: dict) -> None:
+    unsigned = dict(value)
+    unsigned.pop("content_digest", None)
+    value["content_digest"] = canonical_digest(unsigned)
+
+
+def forged_green_attempts() -> list[dict]:
+    attempts = []
+    for index in range(20):
+        attempt = {
+            "format": "recovery-contract-result/v1",
+            "target_ref": TARGET_REF,
+            "test_contract_id": TEST_CONTRACT_ID,
+            "attempt_id": f"forged-{index:02d}",
+            "candidate_revision": None,
+            "cluster": {
+                "cluster_uid": None,
+                "generation": None,
+                "expected_image_digest": None,
+            },
+            "evidence_validity": "valid",
+            "product_result": "passed",
+            "oracle_observation": {"exercise_state": "exercised"},
+            "probes": [
+                {
+                    "probe_kind": kind,
+                    "remote_execution_witness": {"witness_state": "verified"},
+                }
+                for kind in ("baseline", "stale_window", "post_eviction")
+            ],
+            "cleanup": {"ok": True},
+        }
+        redigest(attempt)
+        attempts.append(attempt)
+    return attempts
+
+
 class BoundedRecoveryScenarioTest(unittest.TestCase):
     def test_success_requires_both_fault_probes_and_three_verified_witnesses(self):
         result, driver, partials = run_fixture(valid_fixture())
@@ -186,6 +226,64 @@ class BoundedRecoveryScenarioTest(unittest.TestCase):
         self.assertEqual("mismatch", result["probes"][0]["remote_execution_witness"]["witness_state"])
         self.assertEqual("not_started", result["timeline"]["fault_start"])
         self.assertEqual(1, driver.cleanup_calls)
+
+    def test_exact_deadline_blocks_fault_injection_but_positive_time_allows_it(self):
+        class CountingFaultDriver(ReplayDriver):
+            fault_calls = 0
+
+            def inject_fault(self, deadline: float):
+                self.fault_calls += 1
+                return super().inject_fault(deadline)
+
+        exhausted = valid_fixture()
+        exhausted["config"].update(
+            scenario_budget_seconds=2,
+            probe_budget_seconds=2,
+        )
+        exhausted["probes"]["baseline"]["duration_seconds"] = 2
+        exhausted["fault"]["duration_seconds"] = 0
+        exhausted["cleanup"]["duration_seconds"] = 0
+        exhausted_driver = CountingFaultDriver(exhausted)
+        result, exhausted_driver, _ = run_fixture(exhausted, exhausted_driver)
+
+        self.assertEqual(0, exhausted_driver.fault_calls)
+        self.assertEqual("not_started", result["timeline"]["fault_start"])
+        self.assertEqual("not_evaluated", result["product_result"])
+
+        positive = deepcopy(exhausted)
+        positive["config"]["scenario_budget_seconds"] = 2.001
+        positive_driver = CountingFaultDriver(positive)
+        run_fixture(positive, positive_driver)
+        self.assertEqual(1, positive_driver.fault_calls)
+
+    def test_fault_receipt_timestamp_is_validated_before_publication(self):
+        class TimestampFaultDriver(ReplayDriver):
+            injected_timestamp = RAW_DEAD_ENDPOINT
+
+            def inject_fault(self, deadline: float):
+                receipt = super().inject_fault(deadline)
+                return FaultReceipt(
+                    target_cn=receipt.target_cn,
+                    endpoint=receipt.endpoint,
+                    started_at_utc=self.injected_timestamp,
+                )
+
+        fixture = valid_fixture()
+        malformed_driver = TimestampFaultDriver(fixture)
+        result, malformed_driver, _ = run_fixture(fixture, malformed_driver)
+        encoded = json.dumps(result, sort_keys=True)
+
+        self.assertNotIn(RAW_DEAD_ENDPOINT, encoded)
+        self.assertEqual("not_started", result["timeline"]["fault_start"])
+        self.assertEqual("mismatch", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertIn("contract_error", result["failure_reason"])
+
+        boundary_fixture = valid_fixture()
+        boundary_driver = TimestampFaultDriver(boundary_fixture)
+        boundary_driver.injected_timestamp = "2026-08-24T02:30:00.250000Z"
+        boundary_result, _, _ = run_fixture(boundary_fixture, boundary_driver)
+        self.assertEqual("passed", boundary_result["product_result"])
 
     def test_probe_without_remote_scope_is_not_observed(self):
         fixture = valid_fixture()
@@ -368,10 +466,43 @@ class CampaignTest(unittest.TestCase):
         self.assertEqual(19, result["stale_window_exercised"])
         self.assertEqual({"not_evaluated": 1, "passed": 19}, result["product_result_counts"])
 
+    def test_attempt_validator_preserves_genuine_non_green_results(self):
+        fixtures = []
+        preflight_mismatch = valid_fixture()
+        preflight_mismatch["deployment"]["image_digests"].append("sha256:" + "9" * 64)
+        fixtures.append(preflight_mismatch)
+        stale_miss = valid_fixture()
+        stale_miss["topology"] = [
+            {
+                "at_seconds": 1,
+                "replacement_ready": True,
+                "old_member_visible": False,
+            }
+        ]
+        fixtures.append(stale_miss)
+        harness_failure = valid_fixture()
+        harness_failure["probes"]["stale_window"]["raise"] = "checker crashed"
+        fixtures.append(harness_failure)
+        timeout = valid_fixture()
+        timeout["probes"]["stale_window"]["duration_seconds"] = 10
+        fixtures.append(timeout)
+        cleanup_failure = valid_fixture()
+        cleanup_failure["cleanup"] = {"ok": False, "detail": "remained"}
+        fixtures.append(cleanup_failure)
+        late_cleanup = valid_fixture()
+        late_cleanup["cleanup"]["duration_seconds"] = 60
+        fixtures.append(late_cleanup)
+
+        for fixture in fixtures:
+            with self.subTest(expected=fixture):
+                validate_attempt_result(run_fixture(fixture)[0])
+
     def test_campaign_rejects_wrong_count_duplicate_ids_and_drift(self):
         attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
         with self.assertRaises(ContractError):
             evaluate_campaign(attempts[:-1])
+        with self.assertRaises(ContractError):
+            evaluate_campaign([*attempts, deepcopy(attempts[-1])])
         duplicated = deepcopy(attempts)
         duplicated[1]["attempt_id"] = duplicated[0]["attempt_id"]
         with self.assertRaises(ContractError):
@@ -384,9 +515,57 @@ class CampaignTest(unittest.TestCase):
     def test_campaign_rejects_tampered_attempt_even_if_claimed_result_is_green(self):
         attempts = [run_fixture(valid_fixture(f"attempt-{index:02d}"))[0] for index in range(20)]
         attempts[4] = deepcopy(attempts[4])
-        attempts[4]["timeline"]["fault_start"] = "2026-08-24T00:00:00.000000Z"
+        attempts[4]["attempt_id"] = "attempt-mutated-without-redigest"
         with self.assertRaisesRegex(ContractError, "content digest mismatch"):
             evaluate_campaign(attempts)
+
+    def test_campaign_rejects_recomputed_minimal_forged_green_attempts(self):
+        with self.assertRaisesRegex(ContractError, "attempt schema mismatch"):
+            evaluate_campaign(forged_green_attempts())
+
+    def test_campaign_rejects_recomputed_semantic_forgeries(self):
+        original = [
+            run_fixture(valid_fixture(f"attempt-{index:02d}"))[0]
+            for index in range(20)
+        ]
+
+        def wrong_axis(attempt: dict) -> None:
+            attempt["failure_domain"] = "product"
+
+        def missing_probe(attempt: dict) -> None:
+            del attempt["probes"][1]
+
+        def wrong_witness_digest(attempt: dict) -> None:
+            attempt["probes"][0]["remote_execution_witness_digest"] = (
+                "sha256:" + "9" * 64
+            )
+
+        def wrong_timeline(attempt: dict) -> None:
+            attempt["timeline"]["recovery_frontier"] = attempt["timeline"][
+                "stale_probe_finished_at"
+            ]
+
+        def string_cleanup_bool(attempt: dict) -> None:
+            attempt["cleanup"]["ok"] = "true"
+
+        def untyped_cluster(attempt: dict) -> None:
+            attempt["cluster"]["cluster_uid"] = None
+
+        cases = (
+            (wrong_axis, "result axes"),
+            (missing_probe, "result axes"),
+            (wrong_witness_digest, "witness digest mismatch"),
+            (wrong_timeline, "recovery frontier"),
+            (string_cleanup_bool, "must be a boolean"),
+            (untyped_cluster, "non-empty bounded string"),
+        )
+        for mutate, message in cases:
+            with self.subTest(case=mutate.__name__):
+                attempts = deepcopy(original)
+                mutate(attempts[0])
+                redigest(attempts[0])
+                with self.assertRaisesRegex(ContractError, message):
+                    evaluate_campaign(attempts)
 
 
 class OfflineCliTest(unittest.TestCase):
@@ -412,6 +591,19 @@ class OfflineCliTest(unittest.TestCase):
             self.assertTrue(output_path.exists())
             self.assertTrue((root / "partial-recovery-contract-result.json").exists())
             self.assertEqual("passed", json.loads(output_path.read_text())["product_result"])
+
+    def test_campaign_cli_rejects_recomputed_minimal_forged_green_attempts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output_path = root / "campaign.json"
+            argv = ["campaign", "--output", str(output_path)]
+            for index, attempt in enumerate(forged_green_attempts()):
+                attempt_path = root / f"attempt-{index:02d}.json"
+                attempt_path.write_text(json.dumps(attempt), encoding="utf-8")
+                argv.extend(("--attempt", str(attempt_path)))
+
+            self.assertEqual(2, main(argv))
+            self.assertFalse(output_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -10,7 +10,11 @@ from bounded_recovery.campaign import evaluate_campaign
 from bounded_recovery.cli import main
 from bounded_recovery.contract import ContractError, canonical_digest
 from bounded_recovery.replay import ReplayDriver
-from bounded_recovery.scenario import BoundedRecoveryScenario, ScenarioConfig
+from bounded_recovery.scenario import (
+    BoundedRecoveryScenario,
+    HarnessFailure,
+    ScenarioConfig,
+)
 
 
 CANDIDATE = "1" * 40
@@ -100,9 +104,11 @@ def valid_fixture(attempt_id: str = "attempt-1") -> dict:
     }
 
 
-def run_fixture(fixture: dict) -> tuple[dict, ReplayDriver, list[dict]]:
+def run_fixture(
+    fixture: dict, driver: ReplayDriver | None = None
+) -> tuple[dict, ReplayDriver, list[dict]]:
     config = ScenarioConfig(**fixture["config"])
-    driver = ReplayDriver(fixture)
+    driver = driver or ReplayDriver(fixture)
     partials = []
     result = BoundedRecoveryScenario(
         config,
@@ -228,6 +234,111 @@ class BoundedRecoveryScenarioTest(unittest.TestCase):
         self.assertEqual("infra_invalid", result["evidence_validity"])
         self.assertEqual("not_evaluated", result["product_result"])
         self.assertEqual("infra", result["failure_domain"])
+
+    def test_string_false_cleanup_is_rejected_and_cannot_pass(self):
+        fixture = valid_fixture()
+        fixture["cleanup"]["ok"] = "false"
+        driver = ReplayDriver(fixture)
+        with self.assertRaisesRegex(ContractError, "cleanup.ok must be a JSON boolean"):
+            driver.cleanup(30)
+
+        result, driver, _ = run_fixture(fixture)
+        self.assertEqual(1, driver.cleanup_calls)
+        self.assertEqual("infra_invalid", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertIsNone(result["cleanup"])
+
+    def test_string_false_topology_flags_are_rejected_and_cannot_pass(self):
+        for field in ("replacement_ready", "old_member_visible"):
+            with self.subTest(field=field):
+                fixture = valid_fixture()
+                fixture["topology"][1][field] = "false"
+                result, driver, _ = run_fixture(fixture)
+
+                self.assertEqual(1, driver.cleanup_calls)
+                self.assertEqual("mismatch", result["evidence_validity"])
+                self.assertEqual("not_evaluated", result["product_result"])
+                self.assertIn("contract_error", result["failure_reason"])
+
+    def test_cleanup_past_shared_deadline_is_infra_invalid(self):
+        fixture = valid_fixture()
+        fixture["cleanup"]["duration_seconds"] = 60
+        result, driver, _ = run_fixture(fixture)
+
+        self.assertEqual(1, driver.cleanup_calls)
+        self.assertGreater(driver.monotonic(), fixture["config"]["scenario_budget_seconds"])
+        self.assertEqual("infra_invalid", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertEqual("infra", result["failure_domain"])
+        self.assertEqual("cleanup_deadline_exceeded", result["failure_reason"])
+        self.assertTrue(result["cleanup"]["ok"])
+
+    def test_cleanup_failure_detail_is_bounded_and_endpoint_redacted(self):
+        fixture = valid_fixture()
+        fixture["cleanup"] = {
+            "ok": False,
+            "detail": "x" * 5000 + f" failed cleanup at {RAW_DEAD_ENDPOINT}",
+        }
+        result, _, _ = run_fixture(fixture)
+        encoded = json.dumps(result, sort_keys=True)
+
+        self.assertNotIn(RAW_DEAD_ENDPOINT, encoded)
+        self.assertIn("cleanup_failed", result["failure_reason"])
+        self.assertIn("diagnostic_digest=sha256:", result["failure_reason"])
+        self.assertIn("source_truncated=true", result["failure_reason"])
+        self.assertIn("cleanup_detail", result["cleanup"]["detail"])
+        self.assertLess(len(result["failure_reason"]), 160)
+        self.assertLess(len(result["cleanup"]["detail"]), 160)
+
+    def test_all_driver_exception_classes_redact_external_endpoint(self):
+        fixture = valid_fixture()
+
+        class PreflightExceptionDriver(ReplayDriver):
+            def __init__(self, value: dict, error: Exception) -> None:
+                super().__init__(value)
+                self.error = error
+
+            def preflight(self, deadline: float):
+                del deadline
+                raise self.error
+
+        cases = (
+            ContractError(f"contract rejected {RAW_DEAD_ENDPOINT}"),
+            HarnessFailure(f"checker failed at {RAW_DEAD_ENDPOINT}"),
+            TimeoutError(f"driver timed out at {RAW_DEAD_ENDPOINT}"),
+            RuntimeError(f"driver crashed at {RAW_DEAD_ENDPOINT}"),
+        )
+        for error in cases:
+            with self.subTest(error=type(error).__name__):
+                driver = PreflightExceptionDriver(fixture, error)
+                result, driver, _ = run_fixture(fixture, driver)
+                encoded = json.dumps(result, sort_keys=True)
+
+                self.assertEqual(1, driver.cleanup_calls)
+                self.assertNotIn(RAW_DEAD_ENDPOINT, encoded)
+                self.assertEqual("not_evaluated", result["product_result"])
+                self.assertIn("diagnostic_digest=sha256:", result["failure_reason"])
+                self.assertLess(len(result["failure_reason"]), 160)
+
+    def test_cleanup_exception_is_bounded_and_endpoint_redacted(self):
+        fixture = valid_fixture()
+
+        class CleanupExceptionDriver(ReplayDriver):
+            def cleanup(self, deadline: float):
+                del deadline
+                self.cleanup_calls += 1
+                raise RuntimeError(f"cleanup crashed at {RAW_DEAD_ENDPOINT}")
+
+        driver = CleanupExceptionDriver(fixture)
+        result, driver, _ = run_fixture(fixture, driver)
+        encoded = json.dumps(result, sort_keys=True)
+
+        self.assertEqual(1, driver.cleanup_calls)
+        self.assertNotIn(RAW_DEAD_ENDPOINT, encoded)
+        self.assertEqual("infra_invalid", result["evidence_validity"])
+        self.assertEqual("not_evaluated", result["product_result"])
+        self.assertIn("cleanup_exception", result["failure_reason"])
+        self.assertIn("diagnostic_digest=sha256:", result["failure_reason"])
 
 
 class CampaignTest(unittest.TestCase):

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -182,6 +182,7 @@ class BoundedRecoveryScenarioTest(unittest.TestCase):
         without_digest = dict(result)
         digest = without_digest.pop("content_digest")
         self.assertEqual(digest, canonical_digest(without_digest))
+        validate_attempt_result(result)
 
     def test_stale_window_miss_is_not_exercised_not_passed(self):
         fixture = valid_fixture()
@@ -314,15 +315,53 @@ class BoundedRecoveryScenarioTest(unittest.TestCase):
         self.assertEqual(1, driver.cleanup_calls)
 
     def test_allowlisted_retriable_stale_failure_can_satisfy_contract(self):
-        fixture = valid_fixture()
-        fixture["probes"]["stale_window"].update(
+        for error_class in (
+            "backend_create_timeout",
+            "retryable_topology_change",
+        ):
+            with self.subTest(error_class=error_class):
+                fixture = valid_fixture()
+                fixture["probes"]["stale_window"].update(
+                    outcome="retriable_error",
+                    consistency_ok=None,
+                    error_class=error_class,
+                )
+                result, _, _ = run_fixture(fixture)
+
+                self.assertEqual("passed", result["product_result"])
+                validate_attempt_result(result)
+
+    def test_invalid_probe_outcome_tuples_fail_closed_before_serialization(self):
+        success_with_error = valid_fixture()
+        success_with_error["probes"]["baseline"]["error_class"] = RAW_DEAD_ENDPOINT
+        retriable_with_consistency = valid_fixture()
+        retriable_with_consistency["probes"]["stale_window"].update(
             outcome="retriable_error",
-            consistency_ok=None,
+            consistency_ok=True,
             error_class="backend_create_timeout",
         )
-        result, _, _ = run_fixture(fixture)
+        retriable_with_external_error = valid_fixture()
+        retriable_with_external_error["probes"]["stale_window"].update(
+            outcome="retriable_error",
+            consistency_ok=None,
+            error_class=RAW_DEAD_ENDPOINT,
+        )
 
-        self.assertEqual("passed", result["product_result"])
+        for fixture in (
+            success_with_error,
+            retriable_with_consistency,
+            retriable_with_external_error,
+        ):
+            with self.subTest(fixture=fixture):
+                result, driver, _ = run_fixture(fixture)
+                encoded = json.dumps(result, sort_keys=True)
+
+                self.assertEqual(1, driver.cleanup_calls)
+                self.assertEqual("mismatch", result["evidence_validity"])
+                self.assertEqual("not_evaluated", result["product_result"])
+                self.assertIn("contract_error", result["failure_reason"])
+                self.assertNotIn(RAW_DEAD_ENDPOINT, encoded)
+                validate_attempt_result(result)
 
     def test_cleanup_failure_invalidates_an_otherwise_passing_attempt(self):
         fixture = valid_fixture()
@@ -604,6 +643,32 @@ class OfflineCliTest(unittest.TestCase):
 
             self.assertEqual(2, main(argv))
             self.assertFalse(output_path.exists())
+
+    def test_replay_rejects_success_with_external_error_class(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture_path = root / "fixture.json"
+            output_path = root / "recovery-contract-result.json"
+            fixture = valid_fixture()
+            fixture["probes"]["baseline"]["error_class"] = RAW_DEAD_ENDPOINT
+            fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+            self.assertEqual(
+                1,
+                main(
+                    [
+                        "replay",
+                        "--fixture",
+                        str(fixture_path),
+                        "--output",
+                        str(output_path),
+                    ]
+                ),
+            )
+            result = json.loads(output_path.read_text())
+            self.assertNotIn(RAW_DEAD_ENDPOINT, json.dumps(result, sort_keys=True))
+            self.assertEqual("not_evaluated", result["product_result"])
+            validate_attempt_result(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the deterministic bounded multi-CN recovery state machine and campaign validator
- enforce deployment/image/generation preflight, stale-topology windows, bounded cleanup, remote witness, redaction, and fail-closed failure domains
- validate exactly 20 synthetic state-machine campaign cases without representing them as live product faults

## Validation
- package tests: 14/14 passed
- exact-20 campaign, timeout, cleanup, tamper, stale-window, witness, and redaction paths are covered

## Scope boundary
- this is the owner-side contract used by the nightly workflow
- real TKE fault injection remains an explicitly approved external operation