### PR TITLE
fix: remove invalid generic chaos cleanup

### DIFF
--- a/tests/test_chaos_thread.py
+++ b/tests/test_chaos_thread.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from thread.chaos_thread import Chaos_Thread
+
+
+class ExecuteChaosTest(unittest.TestCase):
+    def test_cm_chaos_does_not_run_generic_global_cleanup(self):
+        chaos_thread = Chaos_Thread.__new__(Chaos_Thread)
+        chaos_thread.namespace = "mo-chaos-test"
+        chaos_thread.db_config = {}
+        chaos_thread.logger = Mock()
+        chaos_thread.execute_cm_chaos = Mock()
+        task = {"name": "kill-cn", "kubectl_yaml": "kind: PodChaos"}
+
+        with patch(
+            "thread.chaos_thread.subprocess.run",
+            side_effect=AssertionError("unexpected generic kubectl cleanup"),
+        ):
+            chaos_thread.execute_chaos(task)
+
+        chaos_thread.execute_cm_chaos.assert_called_once_with(task)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thread/chaos_thread.py
+++ b/thread/chaos_thread.py
@@ -261,13 +261,6 @@ class Chaos_Thread:
             self.logger.error(f"Error executing command: {e.stderr}")
 
     def execute_chaos(self, task):
-        command_delete_all_cm_chaos = f"kubectl delete chaos -n {self.namespace} --all"
-        try:
-            result = subprocess.run(command_delete_all_cm_chaos, shell=True, check=True, capture_output=True, text=True)
-            self.logger.info(f"{command_delete_all_cm_chaos} success: {result.stdout}")
-        except subprocess.CalledProcessError as e:
-            self.logger.error(f"{command_delete_all_cm_chaos} failed: {e.stderr}")
-
         if 'kubectl_yaml' in task:
             self.execute_cm_chaos(task)
         else:
@@ -286,5 +279,4 @@ class Chaos_Thread:
 
     def stop(self):
         self.stop_event.set()
-
 


### PR DESCRIPTION
## Summary
- remove the invalid generic kubectl delete chaos --all command
- retain per-manifest Chaos Mesh apply/delete lifecycle
- add a regression test that prevents global cleanup from returning

## Why
Chaos Mesh exposes concrete resources such as PodChaos and NetworkChaos, not a generic chaos resource. The old command failed on every task and only produced misleading error noise. Broad cleanup is intentionally avoided so parallel tests are not affected.

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m py_compile thread/chaos_thread.py tests/test_chaos_thread.py
- git diff --cached --check
